### PR TITLE
Add snapshot description to "vultr-cli snapshot list"

### DIFF
--- a/cmd/printer/snapshot.go
+++ b/cmd/printer/snapshot.go
@@ -5,10 +5,10 @@ import (
 )
 
 func Snapshot(snapshot []govultr.Snapshot) {
-	col := columns{"SNAPSHOTID", "DATE CREATED", "SIZE", "STATUS", "OSID", "APPID"}
+	col := columns{"SNAPSHOTID", "DATE CREATED", "SIZE", "STATUS", "OSID", "APPID", "DESCRIPTION"}
 	display(col)
 	for _, s := range snapshot {
-		display(columns{s.SnapshotID, s.DateCreated, s.Size, s.Status, s.OsID, s.AppID})
+		display(columns{s.SnapshotID, s.DateCreated, s.Size, s.Status, s.OsID, s.AppID, s.Description})
 	}
 	flush()
 }


### PR DESCRIPTION
Add description of snapshot so that the user can figure out
which snapshot the ID refers to without logging onto the
web frontend.