### PR TITLE
Add "server destroy" as alias for "server delete"

### DIFF
--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -121,8 +121,9 @@ var bareMetalCreate = &cobra.Command{
 }
 
 var bareMetalDelete = &cobra.Command{
-	Use:   "delete <bareMetalID>",
-	Short: "Delete a bare metal server",
+	Use:     "delete <bareMetalID>",
+	Short:   "Delete a bare metal server",
+	Aliases: []string{"destroy"},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a bareMetalID")

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -107,9 +107,10 @@ var bsCreate = &cobra.Command{
 }
 
 var bsDelete = &cobra.Command{
-	Use:   "delete <blockStorageID>",
-	Short: "",
-	Long:  ``,
+	Use:     "delete <blockStorageID>",
+	Short:   "",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a blockStorageID")

--- a/cmd/dnsDomain.go
+++ b/cmd/dnsDomain.go
@@ -72,9 +72,10 @@ var domainCreate = &cobra.Command{
 }
 
 var domainDelete = &cobra.Command{
-	Use:   "delete <domainName>",
-	Short: "delete a domain",
-	Long:  ``,
+	Use:     "delete <domainName>",
+	Short:   "delete a domain",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a domain name")

--- a/cmd/dnsRecord.go
+++ b/cmd/dnsRecord.go
@@ -104,9 +104,10 @@ var recordlist = &cobra.Command{
 }
 
 var recordDelete = &cobra.Command{
-	Use:   "delete <domainName> <recordID>",
-	Short: "delete dns record",
-	Long:  ``,
+	Use:     "delete <domainName> <recordID>",
+	Short:   "delete dns record",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.New("please provide a domainName & recordID")

--- a/cmd/firewallGroup.go
+++ b/cmd/firewallGroup.go
@@ -61,7 +61,7 @@ var firewallGroupCreate = &cobra.Command{
 var firewallGroupDelete = &cobra.Command{
 	Use:     "delete <firewallGroupID>",
 	Short:   "Delete a firewall group",
-	Aliases: []string{"d"},
+	Aliases: []string{"d", "destroy"},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a firewallGroupID")

--- a/cmd/firewallRule.go
+++ b/cmd/firewallRule.go
@@ -75,7 +75,7 @@ var firewallRuleCreate = &cobra.Command{
 var firewallRuleDelete = &cobra.Command{
 	Use:     "delete <firewallGroupID> <firewallRuleNumber>",
 	Short:   "Delete a firewall rule",
-	Aliases: []string{"d"},
+	Aliases: []string{"d", "destroy"},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.New("please provide a firewallGroupID and firewallRuleNumber")

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -104,9 +104,10 @@ var isoCreate = &cobra.Command{
 }
 
 var isoDelete = &cobra.Command{
-	Use:   "delete <isoID>",
-	Short: "delete a private iso",
-	Long:  ``,
+	Use:     "delete <isoID>",
+	Short:   "delete a private iso",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an isoID")

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -60,9 +60,10 @@ var networkList = &cobra.Command{
 }
 
 var networkDelete = &cobra.Command{
-	Use:   "delete <networkID>",
-	Short: "delete a private network",
-	Long:  ``,
+	Use:     "delete <networkID>",
+	Short:   "delete a private network",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a networkID")

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -81,9 +81,10 @@ var reservedIPList = &cobra.Command{
 }
 
 var reservedIPDelete = &cobra.Command{
-	Use:   "delete <reservedIPID>",
-	Short: "delete a reserved ip",
-	Long:  ``,
+	Use:     "delete <reservedIPID>",
+	Short:   "delete a reserved ip",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a reservedIP ID")

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -75,9 +75,10 @@ var scriptCreate = &cobra.Command{
 
 // Delete startup script command
 var scriptDelete = &cobra.Command{
-	Use:   "delete <scriptID>",
-	Short: "Delete a startup script",
-	Long:  ``,
+	Use:     "delete <scriptID>",
+	Short:   "Delete a startup script",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a scriptID")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -806,9 +806,10 @@ var createIpv4 = &cobra.Command{
 }
 
 var deleteIpv4 = &cobra.Command{
-	Use:   "delete <instanceID>",
-	Short: "delete ipv4 for instance",
-	Long:  ``,
+	Use:     "delete <instanceID>",
+	Short:   "delete ipv4 for instance",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an instanceID")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -922,9 +922,10 @@ var listIpv6 = &cobra.Command{
 }
 
 var deleteIpv6 = &cobra.Command{
-	Use:   "delete-ipv6 <instanceID>",
-	Short: "Remove a reverse DNS entry for an IPv6 address for an instance",
-	Long:  ``,
+	Use:     "delete-ipv6 <instanceID>",
+	Short:   "Remove a reverse DNS entry for an IPv6 address for an instance",
+	Aliases: []string{"destroy-ipv6"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an instanceID")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -304,9 +304,10 @@ var serverTag = &cobra.Command{
 }
 
 var serverDelete = &cobra.Command{
-	Use:   "delete <instanceID>",
-	Short: "delete a server",
-	Long:  ``,
+	Use:     "delete <instanceID>",
+	Short:   "delete/destroy a server",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an instanceID")

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -89,9 +89,10 @@ var snapshotCreateFromURL = &cobra.Command{
 
 // Delete snapshot command
 var snapshotDelete = &cobra.Command{
-	Use:   "delete <snapshotID>",
-	Short: "Delete a snapshot",
-	Long:  ``,
+	Use:     "delete <snapshotID>",
+	Short:   "Delete a snapshot",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a snapshotID")

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -73,9 +73,10 @@ var sshCreate = &cobra.Command{
 
 // Delete SSH key command
 var sshDelete = &cobra.Command{
-	Use:   "delete <sshKeyID>",
-	Short: "Delete an SSH key",
-	Long:  ``,
+	Use:     "delete <sshKeyID>",
+	Short:   "Delete an SSH key",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an sshKeyID")

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -82,9 +82,10 @@ var userCreate = &cobra.Command{
 
 // Delete User command
 var userDelete = &cobra.Command{
-	Use:   "delete <userID>",
-	Short: "Delete a user",
-	Long:  ``,
+	Use:     "delete <userID>",
+	Short:   "Delete a user",
+	Aliases: []string{"destroy"},
+	Long:    ``,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a userID")


### PR DESCRIPTION
The front end and API refer to the action as destroying a server,
not deleting it, so this makes the command line more consistent
for users.