### PR TITLE
Fix #40 - Add quotes to dns data

### DIFF
--- a/cmd/dnsRecord.go
+++ b/cmd/dnsRecord.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -58,6 +59,11 @@ func DnsRecord() *cobra.Command {
 	return dnsRecordCmd
 }
 
+// Temporary solution to determine if the record type is TXT, in order to
+// add quotes around the value. The API does not accept TXT records without
+//	quotes.
+var regRecordTxt = regexp.MustCompile("([A-Z]|=|_)")
+
 var recordCreate = &cobra.Command{
 	Use:   "create",
 	Short: "create a dns record",
@@ -67,6 +73,10 @@ var recordCreate = &cobra.Command{
 		rType, _ := cmd.Flags().GetString("type")
 		name, _ := cmd.Flags().GetString("name")
 		data, _ := cmd.Flags().GetString("data")
+		// Record data for TXT must be enclosed in quotes
+		if data[0] != '"' && data[len(data)-1] != '"' && regRecordTxt.Match([]byte(data)) {
+			data = fmt.Sprintf("\"%s\"", data)
+		}
 		ttl, _ := cmd.Flags().GetInt("ttl")
 		priority, _ := cmd.Flags().GetInt("priority")
 
@@ -155,6 +165,10 @@ var recordUpdate = &cobra.Command{
 		}
 
 		if data != "" {
+			// Record data for TXT must be enclosed in quotes
+			if data[0] != '"' && data[len(data)-1] != '"' && regRecordTxt.Match([]byte(data)) {
+				data = fmt.Sprintf("\"%s\"", data)
+			}
 			updates.Data = data
 		}
 


### PR DESCRIPTION
Add quotes around TXT data if not exist. The issue is that the client is not aware of the type of the record, and the API will not accept TXT without quotes.

The commands `dns record create` and `dns record update` have consistent behavior with the `data` flag

  * This will work `new_value`, `"\"new_value\""`
  * This will not work `\"new_value\"`

## Description
Guess with a regular expression if the record is `TXT`, and wrap the data in quotes. If the record data has already quotes, it will not escape them. In this case the user must escape the `TXT` value.

## Related Issues
Fixes #40 

### Checklist:

  - [x]   Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
  - [x]  Have you linted your code locally prior to submission?
  - [x]  Have you successfully ran tests with your changes locally?
