### PR TITLE
Add contextual instructions for Vultr API key setup.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,7 +100,8 @@ func initConfig() {
 func initClient() {
 	key := os.Getenv("VULTR_API_KEY")
 	if key == "" {
-		fmt.Println("Please export your VULTR API Key")
+		fmt.Println("Please export your VULTR API key as an environment variable, eg:")
+		fmt.Println("\texport VULTR_API_KEY='<api_key_from_vultr_account>'")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Description
Add contextual command line instruction for exporting the Vultr API key to the proper BASH variable.

### Checklist:

- [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?  
- [X] Have you linted your code locally prior to submission?  
 (if this means `go fmt`, per the [Contributing Guidelines](https://github.com/vultr/vultr-cli/blob/master/CONTRIBUTING.md#overview), then yes)  

- [x] Have you successfully ran tests with your changes locally?
 (unsure if `tests` is defined somewhere other than the readme/contributing docs, but didn't see anything straightforward to run to ensure this step was completed, please advize.)

---
The code builds and executes successfully on Mac OSX v10.13.6, using `golang v1.12.9 darwin/amd64` (installed via Homebrew).

As the only change is a text printout, nothing fundamental should change, hence the slightly half-assed PR.


