### PR TITLE
Fix typo in `backups` alias: "a" -> "b"

### DIFF
--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -28,7 +28,7 @@ import (
 func Backups() *cobra.Command {
 	backupsCmd := &cobra.Command{
 		Use:     "backups",
-		Aliases: []string{"a"},
+		Aliases: []string{"b"},
 		Short:   "Display backups",
 	}
 


### PR DESCRIPTION
Discovered while working on: https://github.com/withfig/autocomplete/pull/550