### PR TITLE
fix go mod v2

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // accountCmd represents the account command

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Applications  represents the application command

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Backups  represents the application command

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // BareMetal represents the baremetal commands

--- a/cmd/bareMetalApp.go
+++ b/cmd/bareMetalApp.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // BareMetalApp represents the baremetal app commands

--- a/cmd/bareMetalOS.go
+++ b/cmd/bareMetalOS.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // BareMetalOS represents the baremetal operating system commands

--- a/cmd/bareMetalUserData.go
+++ b/cmd/bareMetalUserData.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // BareMetalUserData represents the baremetal userdata commands

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // BlockStorageCmd represents the blockStorage command

--- a/cmd/dnsDomain.go
+++ b/cmd/dnsDomain.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // DNSDomain represents the domain sub command

--- a/cmd/dnsRecord.go
+++ b/cmd/dnsRecord.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // DNSRecord represents the dnsRecord command

--- a/cmd/firewallGroup.go
+++ b/cmd/firewallGroup.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // FirewallGroup represents the firewall group commands

--- a/cmd/firewallRule.go
+++ b/cmd/firewallRule.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // FirewallRule represents the firewall rule commands

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Instance represents the instance command

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 var (

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // LoadBalancer represents the load-balancer command

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Network represents the network command

--- a/cmd/objectStorage.go
+++ b/cmd/objectStorage.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // ObjectStorageCmd represents the objStorageCmd command

--- a/cmd/os.go
+++ b/cmd/os.go
@@ -19,7 +19,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Os represents the iso command

--- a/cmd/plans.go
+++ b/cmd/plans.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Plans represents the plans command

--- a/cmd/regions.go
+++ b/cmd/regions.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Regions represents the region command

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // ReservedIP represents the reservedip command

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Script represents the script command

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // Snapshot represents the snapshot command

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // SSHKey represents the ssh-key command

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vultr/govultr/v2"
-	"github.com/vultr/vultr-cli/cmd/printer"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
 // User represents the user command

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vultr/vultr-cli
+module github.com/vultr/vultr-cli/v2
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "github.com/vultr/vultr-cli/cmd"
+import "github.com/vultr/vultr-cli/v2/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Our go.mod was missing the v2 path in the name which caused issues with the go modules repo from syncing it

I built local builds and a container with the fixed v2 path without issues. We'll have to cut a new release for this

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
