### PR TITLE
Add OpenBSD install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ There are three ways to install `vultr-cli`:
 3. Package Manager
   - Arch Linux
   - Brew
+  - OpenBSD (-current)
   - Snap (Coming soon)
   - Chocolatey (Coming soon)
 4. [Docker Hub](https://hub.docker.com/repository/docker/vultr/vultr-cli)
@@ -100,6 +101,12 @@ Then install the formula
 
 ```sh 
 brew install vultr-cli
+```
+
+### Installing on OpenBSD (-current)
+
+```sh
+pkg_add vultr-cli
 ```
 
 ## Using Vultr-cli


### PR DESCRIPTION
## Description
vultr-cli was ported for OpenBSD and is not imported in ports tree and available from the `pkg_add` utility for the -current flavor.