### PR TITLE
Fixed regex for releaser

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check Message
         id: check-msg
         run: |
-          pattern="^Release v[0-9].[0-9].[0-9] #(minor|major|patch)$"
+          pattern="^Release v[0-9]+.[0-9]+.[0-9]+ #(minor|major|patch)$"
           if [[ "${{ github.event.head_commit.message }}" =~ ${pattern} ]]; then
               echo ::set-output name=match::true
           fi


### PR DESCRIPTION
## Description
Fixes regex bug with double digit releases

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
