### PR TITLE
Correct flag name for setting hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In order to use `vultr-cli` you will need to export your [Vultr API KEY](https:/
 `vultr-cli instance list`
 
 ##### Create an instance
-`vultr-cli instance create --region <region-id> --plan <plan-id> --os <os-id> --hostname <hostname>`
+`vultr-cli instance create --region <region-id> --plan <plan-id> --os <os-id> --host <hostname>`
 
 ##### Create a DNS Domain
 `vultr-cli dns domain create --domain <domain-name> --ip <ip-address>`
@@ -133,7 +133,7 @@ In order to use `vultr-cli` you will need to export your [Vultr API KEY](https:/
 ##### Utilizing a boolean flag
 You should use = when using a boolean flag.
 
-`vultr-cli instance create --region <region-id> --plan <plan-id> --os <os-id> --hostname <hostname> --notify=true`
+`vultr-cli instance create --region <region-id> --plan <plan-id> --os <os-id> --host <hostname> --notify=true`
 
 ##### Utilizing the config flag
 The config flag can be used to specify the vultr-cli.yaml file path when it's outside the default location. If the file has the `api-key` defined, the CLI will use the vultr-cli.yaml config, otherwise it will default to reading the environment variable for the api key.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Hit an error when walking through the readme for creating an instance:

```
./vultr-cli instance create --region ord --plan vc2-1c-1gb --os 477 --hostname test --notify=true
Error: unknown flag: --hostname
```
Looks like the flag name was changed in #210

## Related Issues
None, just noticed while on-boarding :)

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
