### PR TITLE
Add `plans metal list` command and update some helptext on `plans`

### DIFF
--- a/cmd/plans.go
+++ b/cmd/plans.go
@@ -24,13 +24,13 @@ import (
 )
 
 var (
-	plansLong = `Get commands available to plans`
+	plansLong    = `Get commands available to plans`
 	plansExample = `
 	#Full example
 	vultr-cli plans
 	`
 
-	plansListLong = `Get all Vultr plans`
+	plansListLong    = `Get all Vultr plans`
 	plansListExample = `
 	#Full example
 	vultr-cli plans list
@@ -49,7 +49,7 @@ func Plans() *cobra.Command {
 		Use:     "plans",
 		Short:   "get information about Vultr plans",
 		Aliases: []string{"p"},
-		Long:	 plansLong,
+		Long:    plansLong,
 		Example: plansExample,
 	}
 
@@ -68,7 +68,7 @@ var planList = &cobra.Command{
 	Use:     "list",
 	Short:   "list plans",
 	Aliases: []string{"l"},
-	Long:	 plansListLong,
+	Long:    plansListLong,
 	Example: plansListExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		planType, _ := cmd.Flags().GetString("type")

--- a/cmd/plans.go
+++ b/cmd/plans.go
@@ -32,6 +32,7 @@ func Plans() *cobra.Command {
 	}
 
 	planCmd.AddCommand(planList)
+	planCmd.AddCommand(PlansMetal())
 
 	planList.Flags().StringP("type", "t", "", "(optional) The type of plans to return. Possible values: 'bare-metal', 'vc2', 'vdc2', 'ssd', 'dedicated'. Defaults to all VPS plans.")
 

--- a/cmd/plans.go
+++ b/cmd/plans.go
@@ -23,12 +23,34 @@ import (
 	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
+var (
+	plansLong = `Get commands available to plans`
+	plansExample = `
+	#Full example
+	vultr-cli plans
+	`
+
+	plansListLong = `Get all Vultr plans`
+	plansListExample = `
+	#Full example
+	vultr-cli plans list
+
+	#Full example with paging
+	vultr-cli plans list --type=vc2 --per-page=5 --cursor="bmV4dF9fdmMyLTJjLTRnYg=="
+	
+	#Shortened with aliased commands
+	vultr-cli p l
+	`
+)
+
 // Plans represents the plans command
 func Plans() *cobra.Command {
 	planCmd := &cobra.Command{
 		Use:     "plans",
 		Short:   "get information about Vultr plans",
 		Aliases: []string{"p"},
+		Long:	 plansLong,
+		Example: plansExample,
 	}
 
 	planCmd.AddCommand(planList)
@@ -46,6 +68,8 @@ var planList = &cobra.Command{
 	Use:     "list",
 	Short:   "list plans",
 	Aliases: []string{"l"},
+	Long:	 plansListLong,
+	Example: plansListExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		planType, _ := cmd.Flags().GetString("type")
 		options := getPaging(cmd)

--- a/cmd/plansMetal.go
+++ b/cmd/plansMetal.go
@@ -24,13 +24,13 @@ import (
 )
 
 var (
-	plansMetalLong = `Get commands available to metal`
+	plansMetalLong    = `Get commands available to metal`
 	plansMetalExample = `
 	#Full example
 	vultr-cli plans metal
 	`
 
-	plansMetalListLong = `Get all Vultr bare metal plans`
+	plansMetalListLong    = `Get all Vultr bare metal plans`
 	plansMetalListExample = `
 	#Full example
 	vultr-cli plans metal list

--- a/cmd/plansMetal.go
+++ b/cmd/plansMetal.go
@@ -1,0 +1,81 @@
+// Copyright © 2019 The Vultr-cli Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
+)
+
+var (
+	plansMetalLong = `Get commands available to metal`
+	plansMetalExample = `
+	#Full example
+	vultr-cli plans metal
+	`
+
+	plansMetalListLong = `Get all Vultr bare metal plans`
+	plansMetalListExample = `
+	#Full example
+	vultr-cli plans metal list
+
+	#Full example with paging
+	vultr-cli plans metal list --per-page=10 --cursor="bmV4dF9fQU1T"
+
+	#Shortened with aliased commands
+	vultr-cli p m l
+	`
+)
+
+// Plans represents the meal sub command
+func PlansMetal() *cobra.Command {
+	planMetalCmd := &cobra.Command{
+		Use:     "metal",
+		Aliases: []string{"m"},
+		Short:   "metal is used to access bare metal commands",
+		Long:    plansMetalLong,
+		Example: plansMetalExample,
+	}
+
+	planMetalCmd.AddCommand(metalList)
+
+	metalList.Flags().StringP("cursor", "c", "", "(optional) Cursor for paging.")
+	metalList.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
+
+	return planMetalCmd
+}
+
+var metalList = &cobra.Command{
+	Use:     "list",
+	Short:   "list bare-metal plans",
+	Long:    plansMetalListLong,
+	Example: plansMetalListExample,
+	Aliases: []string{"l"},
+	Run: func(cmd *cobra.Command, args []string) {
+		options := getPaging(cmd)
+		list, meta, err := client.Plan.ListBareMetal(context.TODO(), options)
+
+		if err != nil {
+			fmt.Printf("error getting bare metal plan list : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.PlanBareMetal(list, meta)
+	},
+}

--- a/cmd/plansMetal.go
+++ b/cmd/plansMetal.go
@@ -43,7 +43,7 @@ var (
 	`
 )
 
-// PlansMetal represents the meal sub command
+// PlansMetal represents the metal sub command
 func PlansMetal() *cobra.Command {
 	planMetalCmd := &cobra.Command{
 		Use:     "metal",

--- a/cmd/plansMetal.go
+++ b/cmd/plansMetal.go
@@ -43,7 +43,7 @@ var (
 	`
 )
 
-// Plans represents the meal sub command
+// PlansMetal represents the meal sub command
 func PlansMetal() *cobra.Command {
 	planMetalCmd := &cobra.Command{
 		Use:     "metal",


### PR DESCRIPTION
## Description
Add a new command to specifically list only bare-metal type plans.  This functionality was hidden in the `plan list --type=bare-metal` command.  The same output is produced with the new `plans metal list` command. 

This change also adds long help text and examples for the `plans` commands.