### PR TITLE
Add VPC support and deprecate networks

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -48,7 +48,7 @@ var (
 	vultr-cli instance c -r="ewr" -p="vc2-1c-1gb" -o=244
 
 	# Full example with attached VPCs 
-	vultr-cli instance create --region="ewr" --plan="vc2-1c-1gb" --os=244 --vpc-attach="08422775-5be0-4371-afba-64b03f9ad22d,13a45caa-9c06-4b5d-8f76-f5281ab172b7" 
+	vultr-cli instance create --region="ewr" --plan="vc2-1c-1gb" --os=244 --vpc-ids="08422775-5be0-4371-afba-64b03f9ad22d,13a45caa-9c06-4b5d-8f76-f5281ab172b7" 
 
 	# Full example with assigned ssh keys
 	vultr-cli instance create --region ewr --plan vc2-1c-1gb --os 244 --ssh-keys="a14b6539-5583-41e8-a035-c07a76897f2b,be624232-56c7-4d5c-bf87-9bdaae7a1fbd"
@@ -95,9 +95,9 @@ func Instance() *cobra.Command {
 	instanceCreate.Flags().StringP("script-id", "", "", "script id of the startup script")
 	instanceCreate.Flags().BoolP("ipv6", "", false, "enable ipv6 | true or false")
 	instanceCreate.Flags().BoolP("private-network", "", false, "Deprecated: use vpc-enable instead. enable private network | true or false")
-	instanceCreate.Flags().StringSliceP("network", "", []string{}, "Deprecated: use vpc-attach instead. network IDs you want to assign to the instance")
+	instanceCreate.Flags().StringSliceP("network", "", []string{}, "Deprecated: use vpc-ids instead. network IDs you want to assign to the instance")
 	instanceCreate.Flags().BoolP("vpc-enable", "", false, "enable VPC | true or false")
-	instanceCreate.Flags().StringSliceP("vpc-attach", "", []string{}, "VPC IDs you want to assign to the instance")
+	instanceCreate.Flags().StringSliceP("vpc-ids", "", []string{}, "VPC IDs you want to assign to the instance")
 	instanceCreate.Flags().StringP("label", "l", "", "label you want to give this instance")
 	instanceCreate.Flags().StringSliceP("ssh-keys", "s", []string{}, "ssh keys you want to assign to the instance")
 	instanceCreate.Flags().BoolP("auto-backup", "b", false, "enable auto backups | true or false")
@@ -1070,7 +1070,7 @@ var instanceCreate = &cobra.Command{
 		privateNetwork, _ := cmd.Flags().GetBool("private-network")
 		networks, _ := cmd.Flags().GetStringSlice("network")
 		vpcEnable, _ := cmd.Flags().GetBool("vpc-enable")
-		vpcAttach, _ := cmd.Flags().GetStringSlice("vpc-attach")
+		vpcAttach, _ := cmd.Flags().GetStringSlice("vpc-ids")
 		label, _ := cmd.Flags().GetString("label")
 		ssh, _ := cmd.Flags().GetStringSlice("ssh-keys")
 		backup, _ := cmd.Flags().GetBool("auto-backup")
@@ -1142,6 +1142,10 @@ var instanceCreate = &cobra.Command{
 		}
 		if privateNetwork || vpcEnable {
 			opt.EnableVPC = govultr.BoolToBoolPtr(true)
+		}
+		if privateNetwork && vpcEnable {
+			fmt.Println("--private-network is deprecated.  Instead, use only --vpc-enable.")
+			os.Exit(1)
 		}
 		if userData != "" {
 			opt.UserData = base64.StdEncoding.EncodeToString([]byte(userData))

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -25,12 +25,22 @@ import (
 	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
+var (
+	netLong       = ``
+	netGetLong    = ``
+	netCreateLong = ``
+	netUpdateLong = ``
+	netDeleteLong = ``
+	netListLong   = ``
+)
+
 // Network represents the network command
 func Network() *cobra.Command {
 	networkCmd := &cobra.Command{
-		Use:   "network",
-		Short: "network interacts with network actions",
-		Long:  ``,
+		Use:        "network",
+		Short:      "network interacts with network actions",
+		Long:       netLong,
+		Deprecated: "Use vpc instead.",
 	}
 
 	networkCmd.AddCommand(networkGet, networkList, networkDelete, networkCreate)
@@ -50,9 +60,10 @@ func Network() *cobra.Command {
 }
 
 var networkGet = &cobra.Command{
-	Use:   "get <networkID>",
-	Short: "get a private network",
-	Long:  ``,
+	Use:        "get <networkID>",
+	Short:      "get a private network",
+	Long:       netGetLong,
+	Deprecated: "Use vpc get instead.",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a networkID")
@@ -72,9 +83,10 @@ var networkGet = &cobra.Command{
 }
 
 var networkList = &cobra.Command{
-	Use:   "list",
-	Short: "list all private networks",
-	Long:  ``,
+	Use:        "list",
+	Short:      "list all private networks",
+	Long:       netListLong,
+	Deprecated: "Use vpc list instead.",
 	Run: func(cmd *cobra.Command, args []string) {
 		options := getPaging(cmd)
 		network, meta, err := client.Network.List(context.Background(), options)
@@ -88,10 +100,11 @@ var networkList = &cobra.Command{
 }
 
 var networkDelete = &cobra.Command{
-	Use:     "delete <networkID>",
-	Short:   "delete a private network",
-	Aliases: []string{"destroy"},
-	Long:    ``,
+	Use:        "delete <networkID>",
+	Short:      "delete a private network",
+	Aliases:    []string{"destroy"},
+	Long:       netDeleteLong,
+	Deprecated: "Use vpc delete instead.",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide a networkID")
@@ -110,9 +123,10 @@ var networkDelete = &cobra.Command{
 }
 
 var networkCreate = &cobra.Command{
-	Use:   "create",
-	Short: "create a private network",
-	Long:  ``,
+	Use:        "create",
+	Short:      "create a private network",
+	Long:       netCreateLong,
+	Deprecated: "Use vpc create instead.",
 	Run: func(cmd *cobra.Command, args []string) {
 		region, _ := cmd.Flags().GetString("region-id")
 		description, _ := cmd.Flags().GetString("description")

--- a/cmd/printer/vpc.go
+++ b/cmd/printer/vpc.go
@@ -1,0 +1,21 @@
+package printer
+
+import "github.com/vultr/govultr/v2"
+
+func VPCList(vpc []govultr.VPC, meta *govultr.Meta) {
+	col := columns{"ID", "REGION", "DESCRIPTION", "V4 SUBNET", "V4 SUBNET MASK", "DATE CREATED"}
+	display(col)
+	for _, n := range vpc {
+		display(columns{n.ID, n.Region, n.Description, n.V4Subnet, n.V4SubnetMask, n.DateCreated})
+	}
+
+	Meta(meta)
+	flush()
+}
+
+func VPC(vpc *govultr.VPC) {
+	display(columns{"ID", "REGION", "DESCRIPTION", "V4 SUBNET", "V4 SUBNET MASK", "DATE CREATED"})
+	display(columns{vpc.ID, vpc.Region, vpc.Description, vpc.V4Subnet, vpc.V4SubnetMask, vpc.DateCreated})
+
+	flush()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,7 @@ func init() {
 	rootCmd.AddCommand(Snapshot())
 	rootCmd.AddCommand(SSHKey())
 	rootCmd.AddCommand(User())
+	rootCmd.AddCommand(VPC())
 	cobra.OnInitialize(initConfig)
 }
 

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -1,0 +1,220 @@
+// Copyright © 2022 The Vultr-cli Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vultr/govultr/v2"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
+)
+
+var (
+	vpcLong    = `Access information about VPCs on the account and perform CRUD operations`
+	vpcExample = `
+	# Full example
+	vultr-cli vpc
+	`
+	vpcGetLong    = `Display information for a specific VPC`
+	vpcGetExample = `
+	# Full example
+	vultr-cli vpc get 9fd4dcf5-7108-4641-9969-b2b9a8f77990
+
+	# Shortened example with aliases
+	vultr-cli vpc g 9fd4dcf5-7108-4641-9969-b2b9a8f77990
+	`
+	vpcCreateLong    = `Create a new VPC with desired options`
+	vpcCreateExample = `
+	# Full example
+	vultr-cli vpc create --region="ewr" --description="Example VPC" --subnet="10.200.0.0" --size=24
+
+	--region is required.  Everything else is optional
+
+	# Shortened example with aliases
+	vultr-cli vpc c -r="ewr" -d="Example VPC" -s="10.200.0.0" -z=24
+	`
+	vpcUpdateLong    = `Update an existing VPC with the supplied information`
+	vpcUpdateExample = `
+	# Full example
+	vultr-cli vpc update fe8cfe1d-b25c-4c3c-8dfe-e5784bade8d9 --description="Example Updated VPC"
+
+	# Shortned example with aliases
+	vultr-cli vpc u fe8cfe1d-b25c-4c3c-8dfe-e5784bade8d9 -d="Example Updated VPC"
+	`
+	vpcDeleteLong    = `Delete an existing VPC`
+	vpcDeleteExample = `
+	#Full example
+	vultr-cli vpc delete 6b8d8af9-e74a-4829-850d-647f75a056ca
+
+	#Shortened example with aliases
+	vultr-cli vpc d 6b8d8af9-e74a-4829-850d-647f75a056ca
+	`
+	vpcListLong    = `List all available VPC information on the account`
+	vpcListExample = `
+	# Full example
+	vultr-cli vpc list
+
+	# Shortened example with aliases
+	vultr-cli vpc l
+	`
+)
+
+// VPC represents the vpc command
+func VPC() *cobra.Command {
+	vpcCmd := &cobra.Command{
+		Use:     "vpc",
+		Short:   "Interact with VPCs",
+		Long:    vpcLong,
+		Example: vpcExample,
+	}
+
+	vpcCmd.AddCommand(vpcGet, vpcList, vpcDelete, vpcCreate, vpcUpdate)
+	vpcCreate.Flags().StringP("region", "r", "", "The ID of the region in which to create the VPC")
+	vpcCreate.Flags().StringP("description", "d", "", "The description of the VPC")
+	vpcCreate.Flags().StringP("subnet", "s", "", "The IPv4 VPC in CIDR notation.")
+	vpcCreate.Flags().IntP("size", "z", 0, "The number of bits for the netmask in CIDR notation.")
+	vpcCreate.MarkFlagRequired("region")
+
+	vpcList.Flags().StringP("cursor", "c", "", "(optional) Cursor for paging.")
+	vpcList.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
+
+	vpcUpdate.Flags().StringP("description", "d", "", "The description of the VPC")
+	vpcUpdate.MarkFlagRequired("description")
+
+	return vpcCmd
+}
+
+var vpcGet = &cobra.Command{
+	Use:     "get <VPCID>",
+	Aliases: []string{"g"},
+	Short:   "get a VPC",
+	Long:    vpcGetLong,
+	Example: vpcGetExample,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a VPCID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		vpc, err := client.VPC.Get(context.Background(), id)
+		if err != nil {
+			fmt.Printf("error getting VPC : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.VPC(vpc)
+	},
+}
+
+var vpcList = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"l"},
+	Short:   "list all VPCs",
+	Long:    vpcListLong,
+	Example: vpcListExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		options := getPaging(cmd)
+		vpc, meta, err := client.VPC.List(context.Background(), options)
+		if err != nil {
+			fmt.Printf("error getting VPC list : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.VPCList(vpc, meta)
+	},
+}
+
+var vpcDelete = &cobra.Command{
+	Use:     "delete <VPCID>",
+	Aliases: []string{"destroy", "d"},
+	Short:   "delete a VPC",
+	Long:    vpcDeleteLong,
+	Example: vpcDeleteExample,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a VPCID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		if err := client.VPC.Delete(context.Background(), id); err != nil {
+			fmt.Printf("error deleting VPC: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Deleted VPC")
+	},
+}
+
+var vpcCreate = &cobra.Command{
+	Use:     "create",
+	Aliases: []string{"c"},
+	Short:   "create a VPC",
+	Long:    vpcCreateLong,
+	Example: vpcCreateExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		region, _ := cmd.Flags().GetString("region")
+		description, _ := cmd.Flags().GetString("description")
+		subnet, _ := cmd.Flags().GetString("subnet")
+		size, _ := cmd.Flags().GetInt("size")
+
+		options := &govultr.VPCReq{
+			Region:       region,
+			Description:  description,
+			V4Subnet:     subnet,
+			V4SubnetMask: size,
+		}
+
+		vpc, err := client.VPC.Create(context.Background(), options)
+		if err != nil {
+			fmt.Printf("error creating VPC: %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.VPC(vpc)
+	},
+}
+
+var vpcUpdate = &cobra.Command{
+	Use:     "update",
+	Aliases: []string{"u"},
+	Short:   "update a VPC",
+	Long:    vpcUpdateLong,
+	Example: vpcUpdateExample,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provid a VPC ID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		description, _ := cmd.Flags().GetString("description")
+
+		err := client.VPC.Update(context.Background(), args[0], description)
+		if err != nil {
+			fmt.Printf("error updating VPC: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("VPC updated")
+	},
+}


### PR DESCRIPTION
This commit adds the VPC support offered by govultr 2.15.x and
deprecates the private network commands.  Note, this means that usage of
the `vultr-cli network` commands will output a deprecation notice which
may throw off output parsers.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Add VPC support and deprecate private network support

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
