### PR TITLE
vultr-cli is now available on all flavors since 7.1 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ brew install vultr-cli
 dnf install vultr-cli
 ```
 
-### Installing on OpenBSD (-current)
+### Installing on OpenBSD
 
 ```sh
 pkg_add vultr-cli


### PR DESCRIPTION
## Description
Update OpenBSD install instructions.
vultr-cli is now available on all OpenBSD flavors since 7.1 release not only on -current as before.

