### PR TITLE
Add tags support to bare metal and instance commands

### DIFF
--- a/cmd/printer/bareMetal.go
+++ b/cmd/printer/bareMetal.go
@@ -5,19 +5,19 @@ import (
 )
 
 func BareMetal(b *govultr.BareMetalServer) {
-	col := columns{"ID", "IP", "TAG", "MAC ADDRESS", "LABEL", "OS", "STATUS", "REGION", "CPU", "RAM", "DISK", "FEATURES"}
+	col := columns{"ID", "IP", "TAG", "TAGS", "MAC ADDRESS", "LABEL", "OS", "STATUS", "REGION", "CPU", "RAM", "DISK", "FEATURES"}
 	display(col)
 
-	display(columns{b.ID, b.MainIP, b.Tag, b.MacAddress, b.Label, b.Os, b.Status, b.Region, b.CPUCount, b.RAM, b.Disk, b.Features})
+	display(columns{b.ID, b.MainIP, b.Tag, b.Tags, b.MacAddress, b.Label, b.Os, b.Status, b.Region, b.CPUCount, b.RAM, b.Disk, b.Features})
 
 	flush()
 }
 
 func BareMetalList(bms []govultr.BareMetalServer, meta *govultr.Meta) {
-	col := columns{"ID", "IP", "TAG", "MAC ADDRESS", "LABEL", "OS", "STATUS", "REGION", "CPU", "RAM", "DISK", "FEATURES"}
+	col := columns{"ID", "IP", "TAG", "TAGS", "MAC ADDRESS", "LABEL", "OS", "STATUS", "REGION", "CPU", "RAM", "DISK", "FEATURES"}
 	display(col)
 	for _, b := range bms {
-		display(columns{b.ID, b.MainIP, b.Tag, b.MacAddress, b.Label, b.Os, b.Status, b.Region, b.CPUCount, b.RAM, b.Disk, b.Features})
+		display(columns{b.ID, b.MainIP, b.Tag, b.Tags, b.MacAddress, b.Label, b.Os, b.Status, b.Region, b.CPUCount, b.RAM, b.Disk, b.Features})
 	}
 
 	Meta(meta)

--- a/cmd/printer/instance.go
+++ b/cmd/printer/instance.go
@@ -34,10 +34,10 @@ func InstanceIPV6(ip []govultr.IPv6, meta *govultr.Meta) {
 }
 
 func InstanceList(instance []govultr.Instance, meta *govultr.Meta) {
-	col := columns{"ID", "IP", "LABEL", "OS", "STATUS", "Region", "CPU", "RAM", "DISK", "BANDWIDTH"}
+	col := columns{"ID", "IP", "TAGS", "LABEL", "OS", "STATUS", "Region", "CPU", "RAM", "DISK", "BANDWIDTH"}
 	display(col)
 	for _, s := range instance {
-		display(columns{s.ID, s.MainIP, s.Label, s.Os, s.Status, s.Region, s.VCPUCount, s.RAM, s.Disk, s.AllowedBandwidth})
+		display(columns{s.ID, s.MainIP, s.Tags, s.Label, s.Os, s.Status, s.Region, s.VCPUCount, s.RAM, s.Disk, s.AllowedBandwidth})
 	}
 
 	Meta(meta)
@@ -66,6 +66,7 @@ func Instance(instance *govultr.Instance) {
 	display(columns{"INTERNAL IP", instance.InternalIP})
 	display(columns{"KVM URL", instance.KVM})
 	display(columns{"TAG", instance.Tag})
+	display(columns{"TAGS", instance.Tags})
 	display(columns{"OsID", instance.OsID})
 	display(columns{"AppID", instance.AppID})
 	display(columns{"FIREWALL GROUP ID", instance.FirewallGroupID})


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Add support for new tags feature.  Include tags in list output for bare metal and instance commands.  Add new tags command to update tags on bare metal or instances.  Add new tags flag to create commands for bare-metal

### Testing:
* Create new instance with tags
`go run main.go instance c -r="ewr" -p="vc2-1c-1gb" -o=244 --tags="cli-new-tags,cli-new`
* Check tags in list
`go run main.go instance list`
* Update tags on existing instance:
`go run main.go instance tags "fcaddb17-7757-4b70-806c-1a9c38eda637" --tags="cli-tag-a,cli-tag-z`
* Create new bare metal with tags
`go run main.go bare-metal create --label="vcli-bm-i" --plan="vbm-4c-32gb" --region="ewr"  --tags="test-1,test-2" --os="244"`
* Check list output:
`go run main.go bare-metal list`
* Update tags on existing bm server:
`go run main.go bm tags "62e236d6-bb98-42c8-b52f-080d8b7ec973" -t="cli-3,cli-2"` 

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
