### PR TITLE
Add VKE auto scaler options

### DIFF
--- a/cmd/printer/kubernetes.go
+++ b/cmd/printer/kubernetes.go
@@ -28,6 +28,9 @@ func Clusters(cluster []govultr.Cluster, meta *govultr.Meta) {
 			display(columns{"PLAN", np.Plan})
 			display(columns{"STATUS", np.Status})
 			display(columns{"NODE QUANTITY", np.NodeQuantity})
+			display(columns{"AUTO SCALER", np.AutoScaler})
+			display(columns{"MIN NODES", np.MinNodes})
+			display(columns{"MAX NODES", np.MaxNodes})
 
 			display(columns{" "})
 			display(columns{"NODES"})
@@ -69,6 +72,9 @@ func Cluster(k *govultr.Cluster) {
 		display(columns{"PLAN", np.Plan})
 		display(columns{"STATUS", np.Status})
 		display(columns{"NODE QUANTITY", np.NodeQuantity})
+		display(columns{"AUTO SCALER", np.AutoScaler})
+		display(columns{"MIN NODES", np.MinNodes})
+		display(columns{"MAX NODES", np.MaxNodes})
 
 		display(columns{" "})
 		display(columns{"NODES"})
@@ -94,6 +100,9 @@ func NodePools(nodepool []govultr.NodePool, meta *govultr.Meta) {
 		display(columns{"PLAN", np.Plan})
 		display(columns{"STATUS", np.Status})
 		display(columns{"NODE QUANTITY", np.NodeQuantity})
+		display(columns{"AUTO SCALER", np.AutoScaler})
+		display(columns{"MIN NODES", np.MinNodes})
+		display(columns{"MAX NODES", np.MaxNodes})
 
 		display(columns{" "})
 		display(columns{"NODES"})
@@ -118,6 +127,9 @@ func NodePool(np *govultr.NodePool) {
 	display(columns{"PLAN", np.Plan})
 	display(columns{"STATUS", np.Status})
 	display(columns{"NODE QUANTITY", np.NodeQuantity})
+	display(columns{"AUTO SCALER", np.AutoScaler})
+	display(columns{"MIN NODES", np.MinNodes})
+	display(columns{"MAX NODES", np.MaxNodes})
 
 	display(columns{" "})
 	display(columns{"NODES"})


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Add support for the VKE auto scaler options in the API.

### Testing
* Create a new cluster with a node pool and autoscaling enabled:
`go run main.go kubernetes create --label="my-cluster" --region="ewr" --version="v1.23.5+3" --node-pools="quantity:1,plan:vc2-1c-2gb,label:my-nodepool,auto-scaler:true,min-nodes:1,max-nodes:2"`
* Update an existing node pool to enable autoscaling:
`go run main.go kubernetes node-pool update <CLUSTER-UUID> <NP-UUID> --auto-scaler=true --min-nodes=3 --max-nodes=4`
* Update an existing node pool to disable autoscaling:
`go run main.go kubernetes node-pool update <CLUSTER-UUID> <NP-UUID> --auto-scaler=false`
* Check the printer output for `list`:
` go run main.go kubernetes list`

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
