### PR TITLE
Add firewall rule ip-type support

### DIFF
--- a/cmd/firewallRule.go
+++ b/cmd/firewallRule.go
@@ -26,11 +26,64 @@ import (
 	"github.com/vultr/vultr-cli/v2/cmd/printer"
 )
 
+var (
+	firewallRuleLong    = `Show commands available for firewall rules`
+	firewallRuleExample = `
+	# Full example
+	vultr-cli firewall rule 
+	
+	# Shortened example with aliases
+	vultr-cli fw r
+	`
+	firewallRuleCreateLong = `
+	Create a new firewall rule in the provided firewall group
+
+	If protocol is TCP or UDP, port must be provided.
+
+	An ip-type of v4 or v6 must be supplied for all rules.
+	`
+	firewallRuleCreateExample = `
+	# Full examples
+	vultr-cli firewall rule create --id=f04ae5aa-ff6a-4078-900d-78cc17dca2d5 --ip-type=v4 --protocol=tcp --size=24 --subnet=127.0.0.0 --port=30000
+
+	vultr-cli firewall rule create --id=f04ae5aa-ff6a-4078-900d-78cc17dca2d5 --ip-type=v4 --protocol=icmp --size=24 --subnet=127.0.0.0
+
+	# Shortened example with aliases
+	vultr-cli fw r c -i=f04ae5aa-ff6a-4078-900d-78cc17dca2d5 --ip-type=v4 -p=tcp -z=24 -s=127.0.0.0 -r=30000
+	`
+	firewallRuleDeleteLong    = `Delete a firewall rule in the provided firewall group`
+	firewallRuleDeleteExample = `
+	# Full example
+	vultr-cli firewall rule delete 704ac064-4ff2-49ca-a6e6-88262cca8f8a f31ade4f-2308-4a58-82c6-2d1bae0837b3
+
+	# Shortened example with aliases
+	vultr-cli fw r d 704ac064-4ff2-49ca-a6e6-88262cca8f8a f31ade4f-2308-4a58-82c6-2d1bae0837b3
+	`
+	firewallRuleGetLong    = `Get a firewall rule in the provided firewall group`
+	firewallRuleGetExample = `
+	# Full example
+	vultr-cli firewall rule get 704ac064-4ff2-49ca-a6e6-88262cca8f8a f31ade4f-2308-4a58-82c6-2d1bae0837b3
+
+	# Shortened example with aliases
+	vultr-cli fw r get 704ac064-4ff2-49ca-a6e6-88262cca8f8a f31ade4f-2308-4a58-82c6-2d1bae0837b3
+	`
+	firewallRuleListLong    = `List all firewall rules in the provided firewall group`
+	firewallRuleListExample = `
+	# Full example
+	vultr-cli firewall rule list 704ac064-4ff2-49ca-a6e6-88262cca8f8a
+
+	# Shortened example with aliases
+	vultr-cli fw r l 704ac064-4ff2-49ca-a6e6-88262cca8f8a 
+	`
+)
+
 // FirewallRule represents the firewall rule commands
 func FirewallRule() *cobra.Command {
 	firewallRuleCmd := &cobra.Command{
 		Use:     "rule",
 		Short:   "rule is used to access firewall rule commands",
+		Long:    firewallRuleLong,
+		Example: firewallRuleExample,
 		Aliases: []string{"r"},
 	}
 
@@ -41,7 +94,8 @@ func FirewallRule() *cobra.Command {
 	firewallRuleCreate.Flags().StringP("subnet", "s", "", "The IPv4 network in CIDR notation.")
 	firewallRuleCreate.Flags().IntP("size", "z", 0, "The number of bits for the netmask in CIDR notation.")
 	firewallRuleCreate.Flags().StringP("source", "o", "", "(optional) When empty, uses value from subnet and size. If \"cloudflare\", allows all Cloudflare IP space through firewall.")
-	firewallRuleCreate.Flags().StringP("type", "t", "", "The type of IP rule - v4 or v6.")
+	firewallRuleCreate.Flags().StringP("type", "t", "", "Deprecated: use ip-type instead. The type of IP rule - v4 or v6.")
+	firewallRuleCreate.Flags().StringP("ip-type", "", "", "The type of IP rule - v4 or v6.")
 
 	firewallRuleCreate.Flags().StringP("port", "r", "", "(optional) TCP/UDP only. This field can be an integer value specifying a port or a colon separated port range.")
 	firewallRuleCreate.Flags().StringP("notes", "n", "", "(optional) This field supports notes up to 255 characters.")
@@ -50,7 +104,6 @@ func FirewallRule() *cobra.Command {
 	firewallRuleCreate.MarkFlagRequired("protocol")
 	firewallRuleCreate.MarkFlagRequired("subnet")
 	firewallRuleCreate.MarkFlagRequired("size")
-	firewallRuleCreate.MarkFlagRequired("type")
 
 	firewallRuleList.Flags().StringP("cursor", "c", "", "(optional) Cursor for paging.")
 	firewallRuleList.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
@@ -61,12 +114,15 @@ func FirewallRule() *cobra.Command {
 var firewallRuleCreate = &cobra.Command{
 	Use:     "create",
 	Short:   "create a firewall rule",
+	Long:    firewallRuleCreateLong,
+	Example: firewallRuleCreateExample,
 	Aliases: []string{"c"},
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		protocol, _ := cmd.Flags().GetString("protocol")
 		subnet, _ := cmd.Flags().GetString("subnet")
-		ipType, _ := cmd.Flags().GetString("type")
+		ipTypeOld, _ := cmd.Flags().GetString("type")
+		ipType, _ := cmd.Flags().GetString("ip-type")
 		size, _ := cmd.Flags().GetInt("size")
 		source, _ := cmd.Flags().GetString("source")
 		port, _ := cmd.Flags().GetString("port")
@@ -74,7 +130,6 @@ var firewallRuleCreate = &cobra.Command{
 
 		options := &govultr.FirewallRuleReq{
 			Protocol:   protocol,
-			IPType:     ipType,
 			Subnet:     subnet,
 			SubnetSize: size,
 			Notes:      notes,
@@ -86,6 +141,24 @@ var firewallRuleCreate = &cobra.Command{
 
 		if source != "" {
 			options.Source = source
+		}
+
+		if ipTypeOld == "" && ipType == "" {
+			fmt.Println("a firewall rule requires an IP type. Pass an --ip-type value of v4 or v6")
+			os.Exit(1)
+		}
+
+		if ipTypeOld != "" && ipType != "" {
+			fmt.Println("--type is deprecated. Instead, use only --ip-type")
+			os.Exit(1)
+		}
+
+		if ipType != "" {
+			options.IPType = ipType
+		}
+
+		if ipTypeOld != "" {
+			options.IPType = ipTypeOld
 		}
 
 		fwr, err := client.FirewallRule.Create(context.Background(), id, options)
@@ -101,6 +174,8 @@ var firewallRuleCreate = &cobra.Command{
 var firewallRuleDelete = &cobra.Command{
 	Use:     "delete <firewallGroupID> <firewallRuleNumber>",
 	Short:   "Delete a firewall rule",
+	Long:    firewallRuleDeleteLong,
+	Example: firewallRuleDeleteExample,
 	Aliases: []string{"d", "destroy"},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
@@ -119,8 +194,10 @@ var firewallRuleDelete = &cobra.Command{
 }
 
 var firewallRuleGet = &cobra.Command{
-	Use:   "get <firewallGroupID> <firewallRuleNumber>",
-	Short: "Get firewall rule",
+	Use:     "get <firewallGroupID> <firewallRuleNumber>",
+	Short:   "Get firewall rule",
+	Long:    firewallRuleGetLong,
+	Example: firewallRuleGetExample,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.New("please provide a firewallGroupID and firewallRuleNumber")
@@ -142,6 +219,8 @@ var firewallRuleGet = &cobra.Command{
 var firewallRuleList = &cobra.Command{
 	Use:     "list <firewallGroupID>",
 	Short:   "List all firewall rules",
+	Long:    firewallRuleListLong,
+	Example: firewallRuleListExample,
 	Aliases: []string{"l"},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {

--- a/cmd/firewallRule.go
+++ b/cmd/firewallRule.go
@@ -49,7 +49,7 @@ var (
 	vultr-cli firewall rule create --id=f04ae5aa-ff6a-4078-900d-78cc17dca2d5 --ip-type=v4 --protocol=icmp --size=24 --subnet=127.0.0.0
 
 	# Shortened example with aliases
-	vultr-cli fw r c -i=f04ae5aa-ff6a-4078-900d-78cc17dca2d5 --ip-type=v4 -p=tcp -z=24 -s=127.0.0.0 -r=30000
+	vultr-cli fw r c -i=f04ae5aa-ff6a-4078-900d-78cc17dca2d5 --t=v4 -p=tcp -z=24 -s=127.0.0.0 -r=30000
 	`
 	firewallRuleDeleteLong    = `Delete a firewall rule in the provided firewall group`
 	firewallRuleDeleteExample = `
@@ -94,8 +94,8 @@ func FirewallRule() *cobra.Command {
 	firewallRuleCreate.Flags().StringP("subnet", "s", "", "The IPv4 network in CIDR notation.")
 	firewallRuleCreate.Flags().IntP("size", "z", 0, "The number of bits for the netmask in CIDR notation.")
 	firewallRuleCreate.Flags().StringP("source", "o", "", "(optional) When empty, uses value from subnet and size. If \"cloudflare\", allows all Cloudflare IP space through firewall.")
-	firewallRuleCreate.Flags().StringP("type", "t", "", "Deprecated: use ip-type instead. The type of IP rule - v4 or v6.")
-	firewallRuleCreate.Flags().StringP("ip-type", "", "", "The type of IP rule - v4 or v6.")
+	firewallRuleCreate.Flags().StringP("type", "", "", "Deprecated: use ip-type instead. The type of IP rule - v4 or v6.")
+	firewallRuleCreate.Flags().StringP("ip-type", "t", "", "The type of IP rule - v4 or v6.")
 
 	firewallRuleCreate.Flags().StringP("port", "r", "", "(optional) TCP/UDP only. This field can be an integer value specifying a port or a colon separated port range.")
 	firewallRuleCreate.Flags().StringP("notes", "n", "", "(optional) This field supports notes up to 255 characters.")

--- a/cmd/printer/firewallRule.go
+++ b/cmd/printer/firewallRule.go
@@ -10,7 +10,7 @@ func FirewallRules(fwr []govultr.FirewallRule, meta *govultr.Meta) {
 	col := columns{"RULE NUMBER", "ACTION", "TYPE", "PROTOCOL", "PORT", "NETWORK", "SOURCE", "NOTES"}
 	display(col)
 	for _, f := range fwr {
-		display(columns{f.ID, f.Action, f.Type, f.Protocol, f.Port, getFirewallNetwork(f.Subnet, f.SubnetSize), getFirewallSource(f.Source), f.Notes})
+		display(columns{f.ID, f.Action, f.IPType, f.Protocol, f.Port, getFirewallNetwork(f.Subnet, f.SubnetSize), getFirewallSource(f.Source), f.Notes})
 	}
 
 	Meta(meta)
@@ -20,7 +20,7 @@ func FirewallRules(fwr []govultr.FirewallRule, meta *govultr.Meta) {
 func FirewallRule(fwr *govultr.FirewallRule) {
 	col := columns{"RULE NUMBER", "ACTION", "TYPE", "PROTOCOL", "PORT", "NETWORK", "SOURCE", "NOTES"}
 	display(col)
-	display(columns{fwr.ID, fwr.Action, fwr.Type, fwr.Protocol, fwr.Port, getFirewallNetwork(fwr.Subnet, fwr.SubnetSize), getFirewallSource(fwr.Source), fwr.Notes})
+	display(columns{fwr.ID, fwr.Action, fwr.IPType, fwr.Protocol, fwr.Port, getFirewallNetwork(fwr.Subnet, fwr.SubnetSize), getFirewallSource(fwr.Source), fwr.Notes})
 	flush()
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
This adds the `--ip-type` flag to conform with recent API changes and deprecates the `type` flag.  Additionally this adds docs for the firewall rule commands and changes the firewall rule printer to use `IPType`

### Testing
* Create a firewall group
`go run main.go firewall group create`
* Use the created group ID to add a new fw rule using the `--ip-type` flag
`go run main.go firewall rule create -i=<GROUP-UUID> --ip-type=v4 -p=tcp -z=24 -s=127.0.0.0 -r=30002`
* Check the output and make sure type is showing as `v4`
* Confirm the `--type` flag still works for backwards compatibility
`go run main.go firewall rule create -i=<GROUP-UUID> --type=v4 -p=tcp -z=24 -s=127.0.0.0 -r=30003`
* Check error output if both `--type` and `--ip-type` are passed in
`go run main.go firewall rule create -i=d7e0e49e-7389-4a9f-9a84-51a1dd719d65 --type=v4 --ip-type=v4 -p=tcp -z=24 -s=127.0.0.0 -r=30004`
* Check that there's an error if `--ip-type` is not passed in (if `--type` is also not passed in)
`go run main.go firewall rule create -i=d7e0e49e-7389-4a9f-9a84-51a1dd719d65 -p=tcp -z=24 -s=127.0.0.0 -r=30005`
* Check the docs 
`go run main.go firewall rule create --help`

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
