### PR TITLE
Json format

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -30,11 +30,15 @@ var accountCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		account, err := client.Account.Get(context.Background())
+		format, _ := cmd.Flags().GetString("format")
 		if err != nil {
 			fmt.Printf("Error getting account information : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Account(account)
+		if format == "json" {
+			printer.AsJson(account)
+		} else {
+			printer.Account(account)
+		}
 	},
 }

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -45,12 +45,21 @@ var appsList = &cobra.Command{
 	Aliases: []string{"l"},
 	Run: func(cmd *cobra.Command, args []string) {
 		options := getPaging(cmd)
+		format, _ := cmd.Flags().GetString("format")
 		apps, meta, err := client.Application.List(context.Background(), options)
 		if err != nil {
 			fmt.Printf("error getting available applications : %v\n", err)
 			os.Exit(1)
 		}
 
-		printer.Application(apps, meta)
+		if format == "json" {
+			l := make([]interface{}, len(apps))
+			for i := range apps {
+				l[i] = apps[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Application(apps, meta)
+		}
 	},
 }

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -45,14 +45,22 @@ var backupsList = &cobra.Command{
 	Short:   "list backups",
 	Aliases: []string{"l"},
 	Run: func(cmd *cobra.Command, args []string) {
+		format, _ := cmd.Flags().GetString("format")
 		options := getPaging(cmd)
 		backups, meta, err := client.Backup.List(context.TODO(), options)
 		if err != nil {
 			fmt.Printf("error getting backups : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Backups(backups, meta)
+		if format == "json" {
+			l := make([]interface{}, len(backups))
+			for i := range backups {
+				l[i] = backups[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Backups(backups, meta)
+		}
 	},
 }
 
@@ -71,7 +79,11 @@ var backupsGet = &cobra.Command{
 			fmt.Printf("error getting backup : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Backup(backup)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(backup)
+		} else {
+			printer.Backup(backup)
+		}
 	},
 }

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -190,7 +190,12 @@ var bareMetalCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.BareMetal(bm)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(bm)
+		} else {
+			printer.BareMetal(bm)
+		}
 	},
 }
 
@@ -225,8 +230,16 @@ var bareMetalList = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.BareMetalList(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.BareMetalList(list, meta)
+		}
 	},
 }
 
@@ -246,7 +259,12 @@ var bareMetalGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.BareMetal(srv)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(srv)
+		} else {
+			printer.BareMetal(srv)
+		}
 	},
 }
 
@@ -265,8 +283,12 @@ var bareMetalGetVNCUrl = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		fmt.Println(vnc.URL)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(vnc)
+		} else {
+			fmt.Println(vnc.URL)
+		}
 	},
 }
 
@@ -286,8 +308,12 @@ var bareMetalBandwidth = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.BareMetalBandwidth(bw)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(bw)
+		} else {
+			printer.BareMetalBandwidth(bw)
+		}
 	},
 }
 
@@ -351,8 +377,16 @@ var bareMetalListIPV4 = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.BareMetalIPV4Info(info, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(info))
+			for i := range info {
+				l[i] = info[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.BareMetalIPV4Info(info, meta)
+		}
 	},
 }
 
@@ -374,7 +408,16 @@ var bareMetalListIPV6 = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.BareMetalIPV6Info(info, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(info))
+			for i := range info {
+				l[i] = info[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.BareMetalIPV6Info(info, meta)
+		}
 	},
 }
 

--- a/cmd/bareMetalApp.go
+++ b/cmd/bareMetalApp.go
@@ -83,7 +83,15 @@ var bareMetalAppChangeList = &cobra.Command{
 			fmt.Printf("error listing available applications : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.AppList(list.Applications)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list.Applications))
+			for i := range list.Applications {
+				l[i] = list.Applications[i]
+			}
+			printer.ManyAsJson(l, &govultr.Meta{})
+		} else {
+			printer.AppList(list.Applications)
+		}
 	},
 }

--- a/cmd/bareMetalOS.go
+++ b/cmd/bareMetalOS.go
@@ -82,7 +82,15 @@ var bareMetalOSChangeList = &cobra.Command{
 			fmt.Printf("error listing available os : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.OsList(list.OS)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list.OS))
+			for i := range list.OS {
+				l[i] = list.OS[i]
+			}
+			printer.ManyAsJson(l, &govultr.Meta{})
+		} else {
+			printer.OsList(list.OS)
+		}
 	},
 }

--- a/cmd/bareMetalUserData.go
+++ b/cmd/bareMetalUserData.go
@@ -57,7 +57,12 @@ var bareMetalGetUserData = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.UserData(u)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(format)
+		} else {
+			printer.UserData(u)
+		}
 	},
 }
 

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -143,8 +143,16 @@ var billingHistoryList = &cobra.Command{
 			fmt.Printf("error getting billing history : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.BillingHistory(history, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(history))
+			for i := range history {
+				l[i] = history[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.BillingHistory(history, meta)
+		}
 	},
 }
 
@@ -162,7 +170,16 @@ var invoicesList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Invoices(history, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(history))
+			for i := range history {
+				l[i] = history[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Invoices(history, meta)
+		}
 	},
 }
 
@@ -186,8 +203,16 @@ var invoiceItemsList = &cobra.Command{
 			fmt.Printf("error getting invoice items : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.InvoiceItems(items, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(items))
+			for i := range items {
+				l[i] = items[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.InvoiceItems(items, meta)
+		}
 	},
 }
 
@@ -210,6 +235,11 @@ var invoiceGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Invoice(invoice)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(invoice)
+		} else {
+			printer.Invoice(invoice)
+		}
 	},
 }

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -221,8 +221,12 @@ var bsCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.SingleBlockStorage(bs)
-
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(bs)
+		} else {
+			printer.SingleBlockStorage(bs)
+		}
 	},
 }
 
@@ -320,7 +324,16 @@ var bsList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.BlockStorage(bs, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(bs))
+			for i := range bs {
+				l[i] = bs[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.BlockStorage(bs, meta)
+		}
 	},
 }
 
@@ -345,7 +358,12 @@ var bsGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.SingleBlockStorage(bs)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(bs)
+		} else {
+			printer.SingleBlockStorage(bs)
+		}
 	},
 }
 

--- a/cmd/dnsDomain.go
+++ b/cmd/dnsDomain.go
@@ -84,7 +84,12 @@ var domainCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Domain(dns)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(dns)
+		} else {
+			printer.Domain(dns)
+		}
 	},
 }
 
@@ -150,7 +155,12 @@ var secInfo = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.SecInfo(info)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(info)
+		} else {
+			printer.SecInfo(info)
+		}
 	},
 }
 
@@ -166,7 +176,12 @@ var domainGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Domain(domain)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(domain)
+		} else {
+			printer.Domain(domain)
+		}
 	},
 }
 
@@ -181,8 +196,16 @@ var domainList = &cobra.Command{
 			fmt.Printf("error getting domains : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.DomainList(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.DomainList(list, meta)
+		}
 	},
 }
 
@@ -203,8 +226,12 @@ var soaInfo = &cobra.Command{
 			fmt.Printf("error toggling dnssec : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.SoaInfo(info)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(info)
+		} else {
+			printer.SoaInfo(info)
+		}
 	},
 }
 

--- a/cmd/dnsRecord.go
+++ b/cmd/dnsRecord.go
@@ -109,8 +109,12 @@ var recordCreate = &cobra.Command{
 			fmt.Printf("error while creating dns record : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.DnsRecord(record)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(record)
+		} else {
+			printer.DnsRecord(record)
+		}
 	},
 }
 
@@ -134,7 +138,12 @@ var recordGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.DnsRecord(record)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(record)
+		} else {
+			printer.DnsRecord(record)
+		}
 	},
 }
 
@@ -157,8 +166,16 @@ var recordList = &cobra.Command{
 			fmt.Printf("error while getting dns records : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.DnsRecordsList(records, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(records))
+			for i := range records {
+				l[i] = records[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.DnsRecordsList(records, meta)
+		}
 	},
 }
 

--- a/cmd/firewallGroup.go
+++ b/cmd/firewallGroup.go
@@ -60,7 +60,12 @@ var firewallGroupCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.FirewallGroup(fwg)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(fwg)
+		} else {
+			printer.FirewallGroup(fwg)
+		}
 	},
 }
 
@@ -126,7 +131,16 @@ var firewallGroupGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.FirewallGroups(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.FirewallGroups(list, meta)
+		}
 	},
 }
 
@@ -142,6 +156,15 @@ var firewallGroupList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.FirewallGroups(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.FirewallGroups(list, meta)
+		}
 	},
 }

--- a/cmd/firewallRule.go
+++ b/cmd/firewallRule.go
@@ -179,7 +179,12 @@ var firewallRuleCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.FirewallRule(fwr)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(fwr)
+		} else {
+			printer.FirewallRule(fwr)
+		}
 	},
 }
 
@@ -224,7 +229,12 @@ var firewallRuleGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.FirewallRule(fwRule)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(fwRule)
+		} else {
+			printer.FirewallRule(fwRule)
+		}
 	},
 }
 
@@ -248,6 +258,15 @@ var firewallRuleList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.FirewallRules(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.FirewallRules(list, meta)
+		}
 	},
 }

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -526,8 +526,12 @@ var instanceBandwidth = &cobra.Command{
 			fmt.Printf("error getting bandwidth for instance : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.InstanceBandwidth(bw)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(bw)
+		} else {
+			printer.InstanceBandwidth(bw)
+		}
 	},
 }
 
@@ -550,8 +554,16 @@ var instanceIPV4List = &cobra.Command{
 			fmt.Printf("error getting ipv4 info : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.InstanceIPV4(v4, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(v4))
+			for i := range v4 {
+				l[i] = v4[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.InstanceIPV4(v4, meta)
+		}
 	},
 }
 
@@ -575,7 +587,16 @@ var instanceIPV6List = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.InstanceIPV6(v6, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(v6))
+			for i := range v6 {
+				l[i] = v6[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.InstanceIPV6(v6, meta)
+		}
 	},
 }
 
@@ -592,7 +613,16 @@ var instanceList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.InstanceList(s, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(s))
+			for i := range s {
+				l[i] = s[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.InstanceList(s, meta)
+		}
 	},
 }
 
@@ -613,8 +643,12 @@ var instanceInfo = &cobra.Command{
 			fmt.Printf("error getting instance : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Instance(s)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(s)
+		} else {
+			printer.Instance(s)
+		}
 	},
 }
 
@@ -685,7 +719,16 @@ var osUpdateList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.OsList(list.OS)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list.OS))
+			for i := range list.OS {
+				l[i] = list.OS[i]
+			}
+			printer.ManyAsJson(l, &govultr.Meta{})
+		} else {
+			printer.OsList(list.OS)
+		}
 	},
 }
 
@@ -762,7 +805,16 @@ var appUpdateList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.AppList(list.Applications)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list.Applications))
+			for i := range list.Applications {
+				l[i] = list.Applications[i]
+			}
+			printer.ManyAsJson(l, &govultr.Meta{})
+		} else {
+			printer.AppList(list.Applications)
+		}
 	},
 }
 
@@ -783,8 +835,12 @@ var backupGet = &cobra.Command{
 			fmt.Printf("error getting application info : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.BackupsGet(info)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(info)
+		} else {
+			printer.BackupsGet(info)
+		}
 	},
 }
 
@@ -840,7 +896,12 @@ var isoStatus = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.IsoStatus(info)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(info)
+		} else {
+			printer.IsoStatus(info)
+		}
 	},
 }
 
@@ -1021,7 +1082,16 @@ var upgradePlanList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.PlansList(list.Plans)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list.Plans))
+			for i := range list.Plans {
+				l[i] = list.Plans[i]
+			}
+			printer.ManyAsJson(l, &govultr.Meta{})
+		} else {
+			printer.PlansList(list.Plans)
+		}
 	},
 }
 
@@ -1065,7 +1135,12 @@ var listIpv6 = &cobra.Command{
 			fmt.Printf("error getting the reverse ipv6 list: %v\n", err)
 			os.Exit(1)
 		}
-		printer.ReverseIpv6(rip)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(rip)
+		} else {
+			printer.ReverseIpv6(rip)
+		}
 	},
 }
 
@@ -1258,8 +1333,12 @@ var instanceCreate = &cobra.Command{
 			fmt.Printf("error creating instance : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Instance(instance)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(instance)
+		} else {
+			printer.Instance(instance)
+		}
 	},
 }
 
@@ -1310,7 +1389,12 @@ var getUserData = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.UserData(userData)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(userData)
+		} else {
+			printer.UserData(userData)
+		}
 	},
 }
 

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -67,8 +67,12 @@ var isoPrivateGet = &cobra.Command{
 			fmt.Printf("error getting ISO : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.IsoPrivate(iso)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(iso)
+		} else {
+			printer.IsoPrivate(iso)
+		}
 	},
 }
 
@@ -83,8 +87,16 @@ var isoPrivateList = &cobra.Command{
 			fmt.Printf("error getting private ISOs : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.IsoPrivates(isos, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(isos))
+			for i := range isos {
+				l[i] = isos[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.IsoPrivates(isos, meta)
+		}
 	},
 }
 
@@ -99,8 +111,16 @@ var isoPublic = &cobra.Command{
 			fmt.Printf("error getting public ISOs : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.IsoPublic(isos, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(isos))
+			for i := range isos {
+				l[i] = isos[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.IsoPublic(isos, meta)
+		}
 	},
 }
 
@@ -120,7 +140,12 @@ var isoCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.IsoPrivate(iso)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(iso)
+		} else {
+			printer.IsoPrivate(iso)
+		}
 	},
 }
 

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -362,7 +362,12 @@ var k8Create = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Cluster(kubernetes)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(kubernetes)
+		} else {
+			printer.Cluster(kubernetes)
+		}
 	},
 }
 
@@ -381,7 +386,16 @@ var k8List = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Clusters(k8s, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(k8s))
+			for i := range k8s {
+				l[i] = k8s[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Clusters(k8s, meta)
+		}
 	},
 }
 
@@ -405,7 +419,12 @@ var k8Get = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Cluster(lb)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(lb)
+		} else {
+			printer.Cluster(lb)
+		}
 	},
 }
 
@@ -501,8 +520,12 @@ var k8GetConfig = &cobra.Command{
 			fmt.Printf("error retrieving kube config : %v\n", err)
 			os.Exit(1)
 		}
-
-		fmt.Println(config.KubeConfig)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(config.KubeConfig)
+		} else {
+			fmt.Println(config.KubeConfig)
+		}
 	},
 }
 
@@ -518,8 +541,12 @@ var k8GetVersions = &cobra.Command{
 			fmt.Printf("error retrieving supported versions : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.K8Versions(versions)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(versions)
+		} else {
+			printer.K8Versions(versions)
+		}
 	},
 }
 
@@ -537,7 +564,12 @@ var k8GetUpgrades = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.K8Upgrades(upgrades)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(upgrades)
+		} else {
+			printer.K8Upgrades(upgrades)
+		}
 	},
 }
 
@@ -606,7 +638,12 @@ var npCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.NodePool(np)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(np)
+		} else {
+			printer.NodePool(np)
+		}
 	},
 }
 
@@ -649,7 +686,12 @@ var npUpdate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.NodePool(np)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(np)
+		} else {
+			printer.NodePool(np)
+		}
 	},
 }
 
@@ -751,7 +793,16 @@ var npList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.NodePools(nps, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(nps))
+			for i := range nps {
+				l[i] = nps[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.NodePools(nps, meta)
+		}
 	},
 }
 
@@ -776,7 +827,12 @@ var npGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.NodePool(np)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(np)
+		} else {
+			printer.NodePool(np)
+		}
 	},
 }
 

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -306,7 +306,12 @@ var lbCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.LoadBalancer(lb)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(lb)
+		} else {
+			printer.LoadBalancer(lb)
+		}
 	},
 }
 
@@ -349,7 +354,12 @@ var lbGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.LoadBalancer(lb)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(lb)
+		} else {
+			printer.LoadBalancer(lb)
+		}
 	},
 }
 
@@ -364,8 +374,16 @@ var lbList = &cobra.Command{
 			fmt.Printf("error listing load balancers : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.LoadBalancerList(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.LoadBalancerList(list, meta)
+		}
 	},
 }
 
@@ -537,7 +555,16 @@ var ruleList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.LoadBalancerRuleList(rules, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(rules))
+			for i := range rules {
+				l[i] = rules[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.LoadBalancerRuleList(rules, meta)
+		}
 	},
 }
 
@@ -582,8 +609,12 @@ var ruleGet = &cobra.Command{
 			fmt.Printf("error getting load balancer rule : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.LoadBalancerRule(rule)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(rule)
+		} else {
+			printer.LoadBalancerRule(rule)
+		}
 	},
 }
 
@@ -630,7 +661,16 @@ var fwRuleList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.LoadBalancerFWRuleList(rules, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(rules))
+			for i := range rules {
+				l[i] = rules[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.LoadBalancerFWRuleList(rules, meta)
+		}
 	},
 }
 
@@ -652,8 +692,12 @@ var fwRuleGet = &cobra.Command{
 			fmt.Printf("error getting load balancer rule : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.LoadBalancerFWRule(rule)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(rule)
+		} else {
+			printer.LoadBalancerFWRule(rule)
+		}
 	},
 }
 

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -105,8 +105,16 @@ var networkList = &cobra.Command{
 			fmt.Printf("error getting network list : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.NetworkList(network, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(network))
+			for i := range network {
+				l[i] = network[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.NetworkList(network, meta)
+		}
 	},
 }
 
@@ -157,6 +165,11 @@ var networkCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Network(network)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(network)
+		} else {
+			printer.Network(network)
+		}
 	},
 }

--- a/cmd/objectStorage.go
+++ b/cmd/objectStorage.go
@@ -118,7 +118,16 @@ var objStorageList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.ObjectStorages(objStorage, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(objStorage))
+			for i := range objStorage {
+				l[i] = objStorage[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.ObjectStorages(objStorage, meta)
+		}
 	},
 }
 
@@ -139,8 +148,12 @@ var objStorageGet = &cobra.Command{
 			fmt.Printf("error getting object storage : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.SingleObjectStorage(objStorage)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(objStorage)
+		} else {
+			printer.SingleObjectStorage(objStorage)
+		}
 	},
 }
 
@@ -155,8 +168,16 @@ var objStorageClusterList = &cobra.Command{
 			fmt.Printf("error getting object storage clusters : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.ObjectStorageClusterList(cluster, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(cluster))
+			for i := range cluster {
+				l[i] = cluster[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.ObjectStorageClusterList(cluster, meta)
+		}
 	},
 }
 
@@ -178,7 +199,12 @@ var objStorageS3KeyRegenerate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.ObjStorageS3KeyRegenerate(s3Keys)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(s3Keys)
+		} else {
+			printer.ObjStorageS3KeyRegenerate(s3Keys)
+		}
 	},
 }
 

--- a/cmd/os.go
+++ b/cmd/os.go
@@ -51,6 +51,15 @@ var osList = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		printer.Os(os, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(os))
+			for i := range os {
+				l[i] = os[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Os(os, meta)
+		}
 	},
 }

--- a/cmd/plans.go
+++ b/cmd/plans.go
@@ -81,6 +81,7 @@ var planList = &cobra.Command{
 	Example: plansListExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		planType, _ := cmd.Flags().GetString("type")
+		format, _ := cmd.Flags().GetString("format")
 		options := getPaging(cmd)
 
 		if planType == "bare-metal" {
@@ -90,7 +91,15 @@ var planList = &cobra.Command{
 				os.Exit(1)
 			}
 
-			printer.PlanBareMetal(list, meta)
+			if format == "json" {
+				l := make([]interface{}, len(list))
+				for i := range list {
+					l[i] = list[i]
+				}
+				printer.ManyAsJson(l, meta)
+			} else {
+				printer.PlanBareMetal(list, meta)
+			}
 		} else {
 			list, meta, err := client.Plan.List(context.TODO(), planType, options)
 			if err != nil {
@@ -98,7 +107,15 @@ var planList = &cobra.Command{
 				os.Exit(1)
 			}
 
-			printer.Plan(list, meta)
+			if format == "json" {
+				l := make([]interface{}, len(list))
+				for i := range list {
+					l[i] = list[i]
+				}
+				printer.ManyAsJson(l, meta)
+			} else {
+				printer.Plan(list, meta)
+			}
 		}
 	},
 }

--- a/cmd/plansMetal.go
+++ b/cmd/plansMetal.go
@@ -79,6 +79,15 @@ var metalList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.PlanBareMetal(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.PlanBareMetal(list, meta)
+		}
 	},
 }

--- a/cmd/printer/printer.go
+++ b/cmd/printer/printer.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -43,4 +44,20 @@ func Meta(meta *govultr.Meta) {
 	display(col)
 
 	display(columns{meta.Total, meta.Links.Next, meta.Links.Prev})
+}
+
+type Result struct {
+	Meta    *govultr.Meta `json:"meta"`
+	Results []interface{} `json:"results"`
+}
+
+func ManyAsJson(list []interface{}, meta *govultr.Meta) {
+	result := Result{Results: list, Meta: meta}
+	jsonOutput, _ := json.MarshalIndent(result, "", "    ")
+	fmt.Println(string(jsonOutput))
+}
+
+func AsJson(instance interface{}) {
+	jsonOutput, _ := json.MarshalIndent(instance, "", "    ")
+	fmt.Println(string(jsonOutput))
 }

--- a/cmd/regions.go
+++ b/cmd/regions.go
@@ -55,7 +55,16 @@ var regionList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Regions(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Regions(list, meta)
+		}
 	},
 }
 
@@ -78,6 +87,11 @@ var regionAvailability = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.RegionAvailability(availability)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(availability)
+		} else {
+			printer.RegionAvailability(availability)
+		}
 	},
 }

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -178,8 +178,12 @@ var reservedIPGet = &cobra.Command{
 			fmt.Printf("error getting reserved IP : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.ReservedIP(rip)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(rip)
+		} else {
+			printer.ReservedIP(rip)
+		}
 	},
 }
 
@@ -197,7 +201,16 @@ var reservedIPList = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.ReservedIPList(rip, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(rip))
+			for i := range rip {
+				l[i] = rip[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.ReservedIPList(rip, meta)
+		}
 	},
 }
 
@@ -290,8 +303,12 @@ var reservedIPConvert = &cobra.Command{
 			fmt.Printf("error converting IP to reserved IPs : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.ReservedIP(r)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(r)
+		} else {
+			printer.ReservedIP(r)
+		}
 	},
 }
 
@@ -318,7 +335,12 @@ var reservedIPCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.ReservedIP(r)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(r)
+		} else {
+			printer.ReservedIP(r)
+		}
 	},
 }
 
@@ -347,7 +369,11 @@ var reservedIPUpdate = &cobra.Command{
 			fmt.Printf("error updating reserved IPs : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.ReservedIP(r)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(r)
+		} else {
+			printer.ReservedIP(r)
+		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ const (
 )
 
 var cfgFile string
+var outputFormat string
 var client *govultr.Client
 
 // rootCmd represents the base command when called without any subcommands
@@ -56,6 +57,7 @@ func init() {
 		fmt.Printf("error binding root pflag 'config': %v\n", err)
 	}
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.PersistentFlags().StringVar(&outputFormat, "format", "columns", "Format [default is columns, json is additional option]")
 	rootCmd.AddCommand(accountCmd)
 	rootCmd.AddCommand(Applications())
 	rootCmd.AddCommand(Backups())

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -80,8 +80,12 @@ var scriptCreate = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Script(startup)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(startup)
+		} else {
+			printer.Script(startup)
+		}
 	},
 }
 
@@ -120,8 +124,16 @@ var scriptList = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.ScriptList(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.ScriptList(list, meta)
+		}
 	},
 }
 
@@ -143,8 +155,12 @@ var scriptGet = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Script(script)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(script)
+		} else {
+			printer.Script(script)
+		}
 	},
 }
 

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -74,8 +74,12 @@ var snapshotCreate = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Snapshot(s)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(s)
+		} else {
+			printer.Snapshot(s)
+		}
 	},
 }
 
@@ -96,7 +100,12 @@ var snapshotCreateFromURL = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Snapshot(s)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(s)
+		} else {
+			printer.Snapshot(s)
+		}
 	},
 }
 
@@ -141,7 +150,12 @@ var snapshotGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Snapshot(snapshot)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(snapshot)
+		} else {
+			printer.Snapshot(snapshot)
+		}
 	},
 }
 
@@ -157,7 +171,15 @@ var snapshotList = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Snapshots(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Snapshots(list, meta)
+		}
 	},
 }

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -76,7 +76,12 @@ var sshCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.SSHKey(id)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(id)
+		} else {
+			printer.SSHKey(id)
+		}
 	},
 }
 
@@ -118,8 +123,12 @@ var sshGet = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.SSHKey(ssh)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(ssh)
+		} else {
+			printer.SSHKey(ssh)
+		}
 	},
 }
 
@@ -135,8 +144,16 @@ var sshList = &cobra.Command{
 			fmt.Printf("%v\n", err)
 			os.Exit(1)
 		}
-
-		printer.SSHKeys(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.SSHKeys(list, meta)
+		}
 	},
 }
 

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -96,7 +96,12 @@ var userCreate = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.User(user)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(user)
+		} else {
+			printer.User(user)
+		}
 	},
 }
 
@@ -142,7 +147,12 @@ var userGet = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.User(user)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(user)
+		} else {
+			printer.User(user)
+		}
 	},
 }
 
@@ -158,8 +168,16 @@ var userList = &cobra.Command{
 			fmt.Printf("error while grabbing users %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.Users(list, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(list))
+			for i := range list {
+				l[i] = list[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.Users(list, meta)
+		}
 	},
 }
 

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -125,8 +125,12 @@ var vpcGet = &cobra.Command{
 			fmt.Printf("error getting VPC : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.VPC(vpc)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(vpc)
+		} else {
+			printer.VPC(vpc)
+		}
 	},
 }
 
@@ -143,8 +147,16 @@ var vpcList = &cobra.Command{
 			fmt.Printf("error getting VPC list : %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.VPCList(vpc, meta)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			l := make([]interface{}, len(vpc))
+			for i := range vpc {
+				l[i] = vpc[i]
+			}
+			printer.ManyAsJson(l, meta)
+		} else {
+			printer.VPCList(vpc, meta)
+		}
 	},
 }
 
@@ -195,8 +207,12 @@ var vpcCreate = &cobra.Command{
 			fmt.Printf("error creating VPC: %v\n", err)
 			os.Exit(1)
 		}
-
-		printer.VPC(vpc)
+		format, _ := cmd.Flags().GetString("format")
+		if format == "json" {
+			printer.AsJson(vpc)
+		} else {
+			printer.VPC(vpc)
+		}
 	},
 }
 


### PR DESCRIPTION
## Description
Adds the ability to render output as JSON via the `--format=json` flag. The JSON output parses properly with `jq`, letting us take advantage of piping and more advanced scripting.

For now, we simply marshal the the structs, which have been cast to interfaces, but retain the metadata that informs how they should be marshalled into JSON, including the field names.

## Related Issues
Fixes #72

### Checklist:

* [/] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [/] Have you linted your code locally prior to submission?
* [/] Have you successfully ran tests with your changes locally? (nb: no unit tests, so I just ran each command on one of my accounts)
