### PR TITLE
Fix database update errors and remove db engine/version

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -406,7 +406,7 @@ var databaseUpdate = &cobra.Command{
 		// Make the request
 		database, _, err := client.Database.Update(context.TODO(), args[0], opt)
 		if err != nil {
-			fmt.Printf("error updating managed database : %v \n", err)
+			fmt.Printf("error updating managed database : %v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -406,7 +406,7 @@ var databaseUpdate = &cobra.Command{
 		// Make the request
 		database, _, err := client.Database.Update(context.TODO(), args[0], opt)
 		if err != nil {
-			fmt.Printf("error updating managed database : %v %v\n", err, mysqlRequirePrimaryKey)
+			fmt.Printf("error updating managed database : %v \n", err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
## Description
There were a couple of bugs with the database update endpoint, namely some MySQL errors popping up when trying to update a PostgreSQL subscription and two erroneous flags for database engine and database engine version that are not actually updatable through this endpoint -- just a copy pasta fail.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
