### PR TITLE
Add support for attaching and detaching VPC networks from existing VPS instances

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -61,6 +61,17 @@ var (
 	# Shortened example with aliases
 	vultr-cli instance tags <instanceID> -t="example-tag-1,example-tag-2"
 	`
+	instanceVPCAttachLong    = `Attaches an existing VPC to the specified instance`
+	instanceVPCAttachExample = `
+	# Full example
+	vultr-cli instance vpc attach <instanceID> --vpc-id="2126b7d9-5e2a-491e-8840-838aa6b5f294"
+	`
+
+	instanceVPCDetachLong    = `Detaches an existing VPC from the specified instance`
+	instanceVPCDetachExample = `
+	# Full example
+	vultr-cli instance vpc detach <instanceID> --vpc-id="2126b7d9-5e2a-491e-8840-838aa6b5f294"
+	`
 )
 
 // Instance represents the instance command
@@ -1324,8 +1335,10 @@ var getUserData = &cobra.Command{
 }
 
 var vpcAttach = &cobra.Command{
-	Use:   "attach <instanceID>",
-	Short: "Attach a VPC to an instance",
+	Use:     "attach <instanceID>",
+	Short:   "Attach a VPC to an instance",
+	Long:    instanceVPCAttachLong,
+	Example: instanceVPCAttachExample,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an instance ID")
@@ -1345,8 +1358,10 @@ var vpcAttach = &cobra.Command{
 }
 
 var vpcDetach = &cobra.Command{
-	Use:   "detach <instanceID>",
-	Short: "Detach a VPC from an instance",
+	Use:     "detach <instanceID>",
+	Short:   "Detach a VPC from an instance",
+	Long:    instanceVPCDetachLong,
+	Example: instanceVPCDetachExample,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.New("please provide an instance ID")


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Allow attach/detach of VPC networks with some additional commands under the `instance` command
- `instance vpc attach <instanceID> --vpc-id="<vpcID>"`
- `instance vpc detach <instanceID> --vpc-id="<vpcID>"`

See `instance vpc --help` for more info

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Closes #317 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
