### PR TITLE
Add support for VPC 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Available Commands:
   user           user commands
   version        Display current version of Vultr-cli
   vpc            Interact with VPCs
+  vpc2           Interact with VPC 2.0 networks
 
 Flags:
   --config string   config file (default is $HOME/.vultr-cli.yaml) (default "#HOME/.vultr-cli.yaml")

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -39,7 +39,7 @@ var (
 	# Full example with custom MySQL settings
 	vultr-cli database create --database-engine="mysql" --database-engine-version="8" --region="ewr" --plan="vultr-dbaas-startup-cc-1-55-2" --label="example-db" --mysql-slow-query-log="true" --mysql-long-query-time="2"
 	`
-	databaseUpdateLong    = `Create a new Managed Database with specified plan, region, and database engine/version`
+	databaseUpdateLong    = `Updates a Managed Database with the supplied information`
 	databaseUpdateExample = `
 	# Full example
 	vultr-cli database update --region="sea" --plan="vultr-dbaas-startup-cc-2-80-4"
@@ -49,7 +49,7 @@ var (
 	`
 )
 
-// Instance represents the instance command
+// Database represents the database command
 func Database() *cobra.Command {
 	databaseCmd := &cobra.Command{
 		Use:     "database",

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -1469,7 +1469,7 @@ var vpc2Detach = &cobra.Command{
 		id := args[0]
 		vpcID, _ := cmd.Flags().GetString("vpc-id")
 		if err := client.Instance.DetachVPC2(context.TODO(), id, vpcID); err != nil {
-			fmt.Printf("error detaching VPC : %v\n", err)
+			fmt.Printf("error detaching VPC 2.0 network : %v\n", err)
 			os.Exit(1)
 		}
 		fmt.Println("VPC 2.0 network has been detached")

--- a/cmd/printer/bareMetal.go
+++ b/cmd/printer/bareMetal.go
@@ -58,3 +58,12 @@ func BareMetalVNCUrl(vnc *govultr.VNCUrl) {
 	display(columns{vnc.URL})
 	flush()
 }
+
+// BareMetalVPC2List Generate a printer display of all VPC 2.0 networks attached to a given server
+func BareMetalVPC2List(vpc2s []govultr.VPC2Info) {
+	display(columns{"ID", "MAC ADDRESS", "IP ADDRESS"})
+	for _, r := range vpc2s {
+		display(columns{r.ID, r.MacAddress, r.IPAddress})
+	}
+	flush()
+}

--- a/cmd/printer/instance.go
+++ b/cmd/printer/instance.go
@@ -127,3 +127,14 @@ func ReverseIpv6(rip []govultr.ReverseIP) {
 	}
 	flush()
 }
+
+// InstanceVPC2List Generate a printer display of all VPC 2.0 networks attached to a given instance
+func InstanceVPC2List(vpc2s []govultr.VPC2Info, meta *govultr.Meta) {
+	display(columns{"ID", "MAC ADDRESS", "IP ADDRESS"})
+	for _, r := range vpc2s {
+		display(columns{r.ID, r.MacAddress, r.IPAddress})
+	}
+
+	Meta(meta)
+	flush()
+}

--- a/cmd/printer/vpc2.go
+++ b/cmd/printer/vpc2.go
@@ -15,7 +15,7 @@ func VPC2List(vpc2s []govultr.VPC2, meta *govultr.Meta) {
 	flush()
 }
 
-// VPC2 Generate a printer display of a given VPC 2.0 network
+// VPC2 Generates a printer display of a given VPC 2.0 network
 func VPC2(vpc2 *govultr.VPC2) {
 	display(columns{"ID", "DATE CREATED", "REGION", "DESCRIPTION", "IP BLOCK", "PREFIX LENGTH"})
 	display(columns{vpc2.ID, vpc2.DateCreated, vpc2.Region, vpc2.Description, vpc2.IPBlock, vpc2.PrefixLength})

--- a/cmd/printer/vpc2.go
+++ b/cmd/printer/vpc2.go
@@ -1,0 +1,23 @@
+package printer
+
+import (
+	"github.com/vultr/govultr/v3"
+)
+
+// VPC2List Generates a printer display of all VPC 2.0 networks on the account
+func VPC2List(vpc2s []govultr.VPC2, meta *govultr.Meta) {
+	display(columns{"ID", "DATE CREATED", "REGION", "DESCRIPTION", "IP BLOCK", "PREFIX LENGTH"})
+	for d := range vpc2s {
+		display(columns{vpc2s[d].ID, vpc2s[d].DateCreated, vpc2s[d].Region, vpc2s[d].Description, vpc2s[d].IPBlock, vpc2s[d].PrefixLength})
+	}
+
+	Meta(meta)
+	flush()
+}
+
+// VPC2 Generate a printer display of a given VPC 2.0 network
+func VPC2(vpc2 *govultr.VPC2) {
+	display(columns{"ID", "DATE CREATED", "REGION", "DESCRIPTION", "IP BLOCK", "PREFIX LENGTH"})
+	display(columns{vpc2.ID, vpc2.DateCreated, vpc2.Region, vpc2.Description, vpc2.IPBlock, vpc2.PrefixLength})
+	flush()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ func init() {
 	rootCmd.AddCommand(SSHKey())
 	rootCmd.AddCommand(User())
 	rootCmd.AddCommand(VPC())
+	rootCmd.AddCommand(VPC2())
 	cobra.OnInitialize(initConfig)
 }
 

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -31,7 +31,7 @@ var (
 	# Full example
 	vultr-cli vpc2
 	`
-	vpc2CreateLong    = `Create a new VPC 2.0 network with specified ATTRS_GOES_HERE`
+	vpc2CreateLong    = `Create a new VPC 2.0 network with specified region, description, and network settings`
 	vpc2CreateExample = `
 	# Full example
 	vultr-cli vpc2 create --region="ewr" --description="example-vpc" --ip-block="10.99.0.0" --prefix-length="24"

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -34,7 +34,7 @@ var (
 	vpc2CreateLong    = `Create a new VPC 2.0 network with specified ATTRS_GOES_HERE`
 	vpc2CreateExample = `
 	# Full example
-	vultr-cli vpc2 create --region="ewr" --description="example-vpc" --ip_block="10.99.0.0" --prefix_length="24"
+	vultr-cli vpc2 create --region="ewr" --description="example-vpc" --ip-block="10.99.0.0" --prefix-length="24"
 	`
 	vpc2UpdateLong    = `Updates a VPC 2.0 network with the supplied information`
 	vpc2UpdateExample = `
@@ -61,9 +61,9 @@ func VPC2() *cobra.Command {
 	// VPC2 create flags
 	vpc2Create.Flags().StringP("region", "r", "", "region id for the new vpc network")
 	vpc2Create.Flags().StringP("description", "d", "", "description for the new vpc network")
-	vpc2Create.Flags().StringP("ip_type", "", "", "IP tyoe for the new vpc network")
-	vpc2Create.Flags().StringP("ip_block", "", "", "subnet IP address for the new vpc network")
-	vpc2Create.Flags().IntP("prefix_length", "", 0, "number of bits for the netmask in CIDR notation for the new vpc network")
+	vpc2Create.Flags().StringP("ip-type", "", "", "IP tyoe for the new vpc network")
+	vpc2Create.Flags().StringP("ip-block", "", "", "subnet IP address for the new vpc network")
+	vpc2Create.Flags().IntP("prefix-length", "", 0, "number of bits for the netmask in CIDR notation for the new vpc network")
 
 	// VPC2 update flags
 	vpc2Update.Flags().StringP("description", "d", "", "description for the vpc network")
@@ -99,9 +99,9 @@ var vpc2Create = &cobra.Command{
 
 		// Optional
 		description, _ := cmd.Flags().GetString("description")
-		ipType, _ := cmd.Flags().GetString("ip_type")
-		ipBlock, _ := cmd.Flags().GetString("ip_block")
-		prefixLength, _ := cmd.Flags().GetInt("prefix_length")
+		ipType, _ := cmd.Flags().GetString("ip-type")
+		ipBlock, _ := cmd.Flags().GetString("ip-block")
+		prefixLength, _ := cmd.Flags().GetInt("prefix-length")
 
 		opt := &govultr.VPC2Req{
 			Region:       region,

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -1,0 +1,191 @@
+// Copyright © 2019 The Vultr-cli Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vultr/govultr/v3"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
+)
+
+var (
+	vpc2Long    = `Get commands available to vpc2`
+	vpc2Example = `
+	# Full example
+	vultr-cli vpc2
+	`
+	vpc2CreateLong    = `Create a new VPC 2.0 network with specified ATTRS_GOES_HERE`
+	vpc2CreateExample = `
+	# Full example
+	vultr-cli vpc2 create --region="ewr" --description="example-vpc" --ip_block="10.99.0.0" --prefix_length="24"
+	`
+	vpc2UpdateLong    = `Updates a VPC 2.0 network with the supplied information`
+	vpc2UpdateExample = `
+	# Full example
+	vultr-cli vpc2 update --description="example-vpc"
+	`
+)
+
+// VPC2 represents the VPC2 command
+func VPC2() *cobra.Command {
+	vpc2Cmd := &cobra.Command{
+		Use:     "vpc2",
+		Short:   "commands to interact with vpc2 on vultr",
+		Long:    vpc2Long,
+		Example: vpc2Example,
+	}
+
+	vpc2Cmd.AddCommand(vpc2List, vpc2Create, vpc2Info, vpc2Update, vpc2Delete)
+
+	// VPC2 list flags
+	vpc2List.Flags().StringP("cursor", "c", "", "(optional) Cursor for paging.")
+	vpc2List.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
+
+	// VPC2 create flags
+	vpc2Create.Flags().StringP("region", "r", "", "region id for the new vpc network")
+	vpc2Create.Flags().StringP("description", "d", "", "description for the new vpc network")
+	vpc2Create.Flags().StringP("ip_type", "", "", "IP tyoe for the new vpc network")
+	vpc2Create.Flags().StringP("ip_block", "", "", "subnet IP address for the new vpc network")
+	vpc2Create.Flags().IntP("prefix_length", "", 0, "number of bits for the netmask in CIDR notation for the new vpc network")
+
+	// VPC2 update flags
+	vpc2Update.Flags().StringP("description", "d", "", "description for the vpc network")
+
+	return vpc2Cmd
+}
+
+var vpc2List = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"l"},
+	Short:   "list all available VPC 2.0 networks",
+	Long:    ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		options := getPaging(cmd)
+		s, meta, _, err := client.VPC2.List(context.TODO(), options)
+		if err != nil {
+			fmt.Printf("error getting list of vpc 2.0 networks : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.VPC2List(s, meta)
+	},
+}
+
+var vpc2Create = &cobra.Command{
+	Use:     "create",
+	Short:   "Create a VPC 2.0 network",
+	Aliases: []string{"c"},
+	Long:    vpc2CreateLong,
+	Example: vpc2CreateExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		region, _ := cmd.Flags().GetString("region")
+
+		// Optional
+		description, _ := cmd.Flags().GetString("description")
+		ipType, _ := cmd.Flags().GetString("ip_type")
+		ipBlock, _ := cmd.Flags().GetString("ip_block")
+		prefixLength, _ := cmd.Flags().GetInt("prefix_length")
+
+		opt := &govultr.VPC2Req{
+			Region:       region,
+			Description:  description,
+			IPType:       ipType,
+			IPBlock:      ipBlock,
+			PrefixLength: prefixLength,
+		}
+
+		// Make the request
+		vpc2, _, err := client.VPC2.Create(context.TODO(), opt)
+		if err != nil {
+			fmt.Printf("error creating VPC 2.0 network : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.VPC2(vpc2)
+	},
+}
+
+var vpc2Info = &cobra.Command{
+	Use:   "get <vpc2ID>",
+	Short: "get info about a specific VPC 2.0 network",
+	Long:  ``,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a vpc2ID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		s, _, err := client.VPC2.Get(context.TODO(), args[0])
+		if err != nil {
+			fmt.Printf("error getting VPC 2.0 network : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.VPC2(s)
+	},
+}
+
+var vpc2Update = &cobra.Command{
+	Use:     "update <vpc2ID>",
+	Short:   "Update a VPC 2.0 network",
+	Aliases: []string{"u"},
+	Long:    vpc2UpdateLong,
+	Example: vpc2UpdateExample,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a vpc2ID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		description, _ := cmd.Flags().GetString("description")
+
+		// Make the request
+		err := client.VPC2.Update(context.TODO(), args[0], description)
+		if err != nil {
+			fmt.Printf("error updating VPC 2.0 network : %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("VPC 2.0 network updated")
+	},
+}
+
+var vpc2Delete = &cobra.Command{
+	Use:     "delete <vpc2ID>",
+	Short:   "delete/destroy a VPC 2.0 network",
+	Aliases: []string{"destroy"},
+	Long:    ``,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a vpc2ID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := client.VPC2.Delete(context.Background(), args[0]); err != nil {
+			fmt.Printf("error deleting VPC 2.0 network : %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("Deleted VPC 2.0 network")
+	},
+}


### PR DESCRIPTION
## Description
This PR adds support for VPC2 to the Vultr-CLI project. It includes all of the main VPC2 endpoints as well as the new VPC2 endpoints for the instance and bare metal components of the API. Also cleaned up a couple of comment/example errors left behind in the database component while I was at it.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
