### PR TITLE
Add project name back to the archive file names in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
 archives:
   -
     name_template: >-
+      {{- .ProjectName }}_v
       {{- .Version }}_
       {{- if eq .Os "darwin" }}macOs
       {{- else }}{{ .Os }}{{ end }}_


### PR DESCRIPTION
There was a discrepancy between running it locally and when running it on github.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
An issue with testing the goreleaser locally made it seem like the project name was duplicated

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
