### PR TITLE
Add summarize list options for VKE, VLB & database

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -36,9 +36,6 @@ var (
 	# Full example
 	vultr-cli database list
 
-	# Full example with paging
-	vultr-cli database list --per-page=10 --cursor="bmV4dF9fQU1T"
-
 	# Summarized view
 	vultr-cli database list --summarize
 	`

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -31,6 +31,17 @@ var (
 	# Full example
 	vultr-cli database
 	`
+	databaseListLong    = `Get all databases on your Vultr account`
+	databaseListExample = `
+	# Full example
+	vultr-cli database list
+
+	# Full example with paging
+	vultr-cli database list --per-page=10 --cursor="bmV4dF9fQU1T"
+
+	# Summarized view
+	vultr-cli database list --summarize
+	`
 	databaseCreateLong    = `Create a new Managed Database with specified plan, region, and database engine/version`
 	databaseCreateExample = `
 	# Full example
@@ -78,6 +89,7 @@ func Database() *cobra.Command {
 	databaseList.Flags().StringP("label", "l", "", "(optional) Filter by label.")
 	databaseList.Flags().StringP("tag", "t", "", "(optional) Filter by tag.")
 	databaseList.Flags().StringP("region", "r", "", "(optional) Filter by region.")
+	databaseList.Flags().BoolP("summarize", "", false, "(optional) Summarize the list output. One line per database.")
 
 	// Database create flags
 	databaseCreate.Flags().StringP("database-engine", "e", "", "database engine for the new manaaged database")
@@ -367,7 +379,8 @@ var databaseList = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"l"},
 	Short:   "list all available managed databases",
-	Long:    ``,
+	Long:    databaseListLong,
+	Example: databaseListExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		label, _ := cmd.Flags().GetString("label")
 		tag, _ := cmd.Flags().GetString("tag")
@@ -377,13 +390,19 @@ var databaseList = &cobra.Command{
 			Tag:    tag,
 			Region: region,
 		}
+		summarize, _ := cmd.Flags().GetBool("summarize")
+
 		s, meta, _, err := client.Database.List(context.TODO(), options)
 		if err != nil {
 			fmt.Printf("error getting list of databases : %v\n", err)
 			os.Exit(1)
 		}
 
-		printer.DatabaseList(s, meta)
+		if summarize {
+			printer.DatabaseListSummary(s, meta)
+		} else {
+			printer.DatabaseList(s, meta)
+		}
 	},
 }
 

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -252,6 +252,7 @@ func Kubernetes() *cobra.Command {
 
 	k8List.Flags().StringP("cursor", "c", "", "(optional) cursor for paging.")
 	k8List.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
+	k8List.Flags().BoolP("summarize", "", false, "(optional) Summarize the list output. One line per cluster.")
 
 	k8Update.Flags().StringP("label", "l", "", "label for your kubernetes cluster")
 	if err := k8Update.MarkFlagRequired("label"); err != nil {
@@ -374,6 +375,7 @@ var k8List = &cobra.Command{
 	Example: listExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		options := getPaging(cmd)
+		summarize, _ := cmd.Flags().GetBool("summarize")
 
 		k8s, meta, _, err := client.Kubernetes.ListClusters(context.Background(), options)
 		if err != nil {
@@ -381,7 +383,11 @@ var k8List = &cobra.Command{
 			os.Exit(1)
 		}
 
-		printer.Clusters(k8s, meta)
+		if summarize {
+			printer.ClustersSummary(k8s, meta)
+		} else {
+			printer.Clusters(k8s, meta)
+		}
 	},
 }
 

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -62,6 +62,9 @@ var (
 
 	# Shortened with alias commands
 	vultr-cli k l
+
+	# Summarized view
+	vultr-cli kubernetes list --summarize
 	`
 
 	updateLong    = `Update a specific kubernetes cluster on your Vultr Account`

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -390,7 +390,6 @@ var lbList = &cobra.Command{
 		} else {
 			printer.LoadBalancerList(list, meta)
 		}
-
 	},
 }
 

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -108,7 +108,7 @@ func LoadBalancer() *cobra.Command {
 	// List
 	lbList.Flags().StringP("cursor", "c", "", "(optional) cursor for paging.")
 	lbList.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
-	lbList.Flags().BoolP("summarize", "", false, "(optional) Summarize the list output. One line per cluster.")
+	lbList.Flags().BoolP("summarize", "", false, "(optional) Summarize the list output. One line per load balancer.")
 
 	// Update
 	lbUpdate.Flags().StringP("balancing-algorithm", "b", "roundrobin", "(optional) balancing algorithm that determines server selection | roundrobin or leastconn")

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -33,6 +33,22 @@ var (
 	# Full example
 	vultr-cli load-balancer
 	`
+
+	lbListLong    = `Get all load balancers on your Vultr account`
+	lbListExample = `
+	# Full example
+	vultr-cli load-balancer list
+
+	# Full example with paging
+	vultr-cli load-balancer list --per-page=1 --cursor="bmV4dF9fQU1T"
+
+	# Shortened with alias commands
+	vultr-cli lb l
+
+	# Summarized view
+	vultr-cli load-balancer list --summarize
+	`
+
 	lbCreateLong    = `Create a new Load Balancer with the desired settings`
 	lbCreateExample = `
 	# Full example
@@ -355,9 +371,10 @@ var lbGet = &cobra.Command{
 }
 
 var lbList = &cobra.Command{
-	Use:   "list",
-	Short: "retrieves a list of active load balancers",
-	Long:  ``,
+	Use:     "list",
+	Short:   "retrieves a list of active load balancers",
+	Long:    lbListLong,
+	Example: lbListExample,
 	Run: func(cmd *cobra.Command, args []string) {
 		options := getPaging(cmd)
 		summarize, _ := cmd.Flags().GetBool("summarize")

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -108,6 +108,7 @@ func LoadBalancer() *cobra.Command {
 	// List
 	lbList.Flags().StringP("cursor", "c", "", "(optional) cursor for paging.")
 	lbList.Flags().IntP("per-page", "p", 100, "(optional) Number of items requested per page. Default is 100 and Max is 500.")
+	lbList.Flags().BoolP("summarize", "", false, "(optional) Summarize the list output. One line per cluster.")
 
 	// Update
 	lbUpdate.Flags().StringP("balancing-algorithm", "b", "roundrobin", "(optional) balancing algorithm that determines server selection | roundrobin or leastconn")
@@ -359,13 +360,20 @@ var lbList = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		options := getPaging(cmd)
+		summarize, _ := cmd.Flags().GetBool("summarize")
+
 		list, meta, _, err := client.LoadBalancer.List(context.Background(), options)
 		if err != nil {
 			fmt.Printf("error listing load balancers : %v\n", err)
 			os.Exit(1)
 		}
 
-		printer.LoadBalancerList(list, meta)
+		if summarize {
+			printer.LoadBalancerListSummary(list, meta)
+		} else {
+			printer.LoadBalancerList(list, meta)
+		}
+
 	},
 }
 

--- a/cmd/printer/database.go
+++ b/cmd/printer/database.go
@@ -162,6 +162,17 @@ func DatabaseList(databases []govultr.Database, meta *govultr.Meta) {
 	flush()
 }
 
+// DatabaseListSummary will generate a summarized printer display of all Managed Databases on the account
+func DatabaseListSummary(databases []govultr.Database, meta *govultr.Meta) {
+	display(columns{"ID", "REGION", "LABEL", "STATUS", "ENGINE", "VERSION", "HOST", "PORT", "USER", "PASSWORD"})
+	for _, d := range databases {
+		display(columns{d.ID, d.Region, d.Label, d.Status, d.DatabaseEngine, d.DatabaseEngineVersion, d.Host, d.Port, d.User, d.Password})
+	}
+
+	MetaDBaaS(meta)
+	flush()
+}
+
 // Database will generate a printer display of a given Managed Database
 func Database(database *govultr.Database) {
 	display(columns{"ID", database.ID})

--- a/cmd/printer/kubernetes.go
+++ b/cmd/printer/kubernetes.go
@@ -143,7 +143,7 @@ func NodePool(np *govultr.NodePool) {
 }
 
 func ClustersSummary(clusters []govultr.Cluster, meta *govultr.Meta) {
-	display(columns{"ID", "LABEL", "REGION", "VERSION", "NODEPOOL#", "NODE#"})
+	display(columns{"ID", "LABEL", "STATUS", "REGION", "VERSION", "NODEPOOL#", "NODE#"})
 
 	for _, k := range clusters {
 		nodePoolCount := len(k.NodePools)
@@ -153,7 +153,7 @@ func ClustersSummary(clusters []govultr.Cluster, meta *govultr.Meta) {
 			nodeCount += len(np.Nodes)
 		}
 
-		display(columns{k.ID, k.Label, k.Region, k.Version, nodePoolCount, nodeCount})
+		display(columns{k.ID, k.Label, k.Status, k.Region, k.Version, nodePoolCount, nodeCount})
 	}
 
 	Meta(meta)

--- a/cmd/printer/kubernetes.go
+++ b/cmd/printer/kubernetes.go
@@ -142,6 +142,24 @@ func NodePool(np *govultr.NodePool) {
 	flush()
 }
 
+func ClustersSummary(clusters []govultr.Cluster, meta *govultr.Meta) {
+	display(columns{"ID", "LABEL", "REGION", "VERSION", "NODEPOOL#", "NODE#"})
+
+	for _, k := range clusters {
+		nodePoolCount := len(k.NodePools)
+		var nodeCount int = 0
+
+		for _, np := range k.NodePools {
+			nodeCount += len(np.Nodes)
+		}
+
+		display(columns{k.ID, k.Label, k.Region, k.Version, nodePoolCount, nodeCount})
+	}
+
+	Meta(meta)
+	flush()
+}
+
 func K8Versions(versions *govultr.Versions) {
 	display(columns{"VERSIONS"})
 	for _, v := range versions.Versions {

--- a/cmd/printer/loadBalancer.go
+++ b/cmd/printer/loadBalancer.go
@@ -127,12 +127,21 @@ func LoadBalancerFWRule(rule *govultr.LBFirewallRule) {
 }
 
 func LoadBalancerListSummary(loadbalancer []govultr.LoadBalancer, meta *govultr.Meta) {
-	display(columns{"ID", "LABEL", "STATUS", "REGION", "FORWARD#", "FIREWALL#"})
+	display(columns{"ID", "LABEL", "STATUS", "REGION", "INSTANCE#", "FORWARD#", "FIREWALL#"})
 	for _, lb := range loadbalancer {
 		forwardRuleCount := len(lb.ForwardingRules)
 		firewallRuleCount := len(lb.FirewallRules)
+		instanceCount := len(lb.Instances)
 
-		display(columns{lb.ID, lb.Label, lb.Status, lb.Region, forwardRuleCount, firewallRuleCount})
+		display(columns{
+			lb.ID,
+			lb.Label,
+			lb.Status,
+			lb.Region,
+			instanceCount,
+			forwardRuleCount,
+			firewallRuleCount,
+		})
 	}
 
 	Meta(meta)

--- a/cmd/printer/loadBalancer.go
+++ b/cmd/printer/loadBalancer.go
@@ -125,3 +125,16 @@ func LoadBalancerFWRule(rule *govultr.LBFirewallRule) {
 
 	flush()
 }
+
+func LoadBalancerListSummary(loadbalancer []govultr.LoadBalancer, meta *govultr.Meta) {
+	display(columns{"ID", "LABEL", "STATUS", "REGION", "FORWARD#", "FIREWALL#"})
+	for _, lb := range loadbalancer {
+		forwardRuleCount := len(lb.ForwardingRules)
+		firewallRuleCount := len(lb.FirewallRules)
+
+		display(columns{lb.ID, lb.Label, lb.Status, lb.Region, forwardRuleCount, firewallRuleCount})
+	}
+
+	Meta(meta)
+	flush()
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
The list commands on the database, VLB and VKE return a bunch of data in their printers which is hard to parse at a glance.  This will expose a `--summarize` flag to tabulate some of the general data for each server/cluster it returns.

## Testing
* `go run main.go kubernetes list --summarize`
* `go run main.go load-balancer list --summarize`
* `go run main.go database list --summarize`

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
