### PR TITLE
Allow some commands to be run without authenticating against the API

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -39,7 +39,7 @@ var accountCmd = &cobra.Command{
 		printer.Account(account)
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+		if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 			return errors.New(apiKeyError)
 		}
 		return nil

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -37,4 +37,10 @@ var accountCmd = &cobra.Command{
 
 		printer.Account(account)
 	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if auth := cmd.Context().Value("authenticated"); auth != true {
+			return fmt.Errorf(apiKeyError)
+		}
+		return nil
+	},
 }

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -39,7 +40,7 @@ var accountCmd = &cobra.Command{
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if auth := cmd.Context().Value("authenticated"); auth != true {
-			return fmt.Errorf(apiKeyError)
+			return errors.New(apiKeyError)
 		}
 		return nil
 	},

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -39,7 +39,7 @@ var accountCmd = &cobra.Command{
 		printer.Account(account)
 	},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if auth := cmd.Context().Value("authenticated"); auth != true {
+		if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 			return errors.New(apiKeyError)
 		}
 		return nil

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -32,7 +32,7 @@ func Backups() *cobra.Command {
 		Short:   "Display backups",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -31,7 +31,7 @@ func Backups() *cobra.Command {
 		Aliases: []string{"b"},
 		Short:   "Display backups",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -30,6 +30,12 @@ func Backups() *cobra.Command {
 		Use:     "backups",
 		Aliases: []string{"b"},
 		Short:   "Display backups",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	backupsCmd.AddCommand(backupsList, backupsGet)

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -31,7 +31,7 @@ func Backups() *cobra.Command {
 		Aliases: []string{"b"},
 		Short:   "Display backups",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -63,7 +63,7 @@ func BareMetal() *cobra.Command {
 		Long:    bareMetalLong,
 		Example: bareMetalExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -63,7 +63,7 @@ func BareMetal() *cobra.Command {
 		Long:    bareMetalLong,
 		Example: bareMetalExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -64,7 +64,7 @@ func BareMetal() *cobra.Command {
 		Example: bareMetalExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -62,6 +62,12 @@ func BareMetal() *cobra.Command {
 		Aliases: []string{"bm"},
 		Long:    bareMetalLong,
 		Example: bareMetalExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	bareMetalCmd.AddCommand(

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -95,7 +95,7 @@ func Billing() *cobra.Command {
 		Long:    billingLong,
 		Example: billingExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -96,7 +96,7 @@ func Billing() *cobra.Command {
 		Example: billingExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -94,6 +94,12 @@ func Billing() *cobra.Command {
 		Short:   "Display billing information",
 		Long:    billingLong,
 		Example: billingExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	historyCmd := &cobra.Command{

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -95,7 +95,7 @@ func Billing() *cobra.Command {
 		Long:    billingLong,
 		Example: billingExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -114,7 +114,7 @@ func BlockStorageCmd() *cobra.Command {
 		Long:    `block-storage is used to interact with the block-storage api`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -113,7 +113,7 @@ func BlockStorageCmd() *cobra.Command {
 		Short:   "block storage commands",
 		Long:    `block-storage is used to interact with the block-storage api`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -112,6 +112,12 @@ func BlockStorageCmd() *cobra.Command {
 		Aliases: []string{"bs"},
 		Short:   "block storage commands",
 		Long:    `block-storage is used to interact with the block-storage api`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	bsCmd.AddCommand(bsAttach, bsCreate, bsDelete, bsDetach, bsLabelSet, bsList, bsGet, bsResize)

--- a/cmd/blockStorage.go
+++ b/cmd/blockStorage.go
@@ -113,7 +113,7 @@ func BlockStorageCmd() *cobra.Command {
 		Short:   "block storage commands",
 		Long:    `block-storage is used to interact with the block-storage api`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -67,7 +67,7 @@ func Database() *cobra.Command { //nolint:funlen
 		Long:    databaseLong,
 		Example: databaseExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -66,6 +66,12 @@ func Database() *cobra.Command { //nolint:funlen
 		Short:   "commands to interact with managed databases on vultr",
 		Long:    databaseLong,
 		Example: databaseExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	databaseCmd.AddCommand(databaseList, databaseCreate, databaseInfo, databaseUpdate, databaseDelete)

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -68,7 +68,7 @@ func Database() *cobra.Command { //nolint:funlen
 		Example: databaseExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -67,7 +67,7 @@ func Database() *cobra.Command { //nolint:funlen
 		Long:    databaseLong,
 		Example: databaseExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 )
@@ -28,7 +28,7 @@ func DNS() *cobra.Command {
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -27,7 +27,7 @@ func DNS() *cobra.Command {
 		Short: "dns is used to access dns commands",
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -27,7 +27,7 @@ func DNS() *cobra.Command {
 		Short: "dns is used to access dns commands",
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +26,12 @@ func DNS() *cobra.Command {
 		Use:   "dns",
 		Short: "dns is used to access dns commands",
 		Long:  ``,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	dnsCmd.AddCommand(DNSDomain())

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +27,12 @@ func Firewall() *cobra.Command {
 		Short:   "firewall is used to access firewall commands",
 		Long:    ``,
 		Aliases: []string{"fw"},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	firewallCmd.AddCommand(FirewallGroup(), FirewallRule())

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -28,7 +28,7 @@ func Firewall() *cobra.Command {
 		Long:    ``,
 		Aliases: []string{"fw"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -28,7 +28,7 @@ func Firewall() *cobra.Command {
 		Long:    ``,
 		Aliases: []string{"fw"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +29,7 @@ func Firewall() *cobra.Command {
 		Aliases: []string{"fw"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -95,6 +95,12 @@ func Instance() *cobra.Command { //nolint: funlen,gocyclo
 		Short:   "commands to interact with instances on vultr",
 		Long:    instanceLong,
 		Example: instanceExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	instanceCmd.AddCommand(

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -96,7 +96,7 @@ func Instance() *cobra.Command { //nolint: funlen,gocyclo
 		Long:    instanceLong,
 		Example: instanceExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -96,7 +96,7 @@ func Instance() *cobra.Command { //nolint: funlen,gocyclo
 		Long:    instanceLong,
 		Example: instanceExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -97,7 +97,7 @@ func Instance() *cobra.Command { //nolint: funlen,gocyclo
 		Example: instanceExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -32,6 +32,12 @@ func ISO() *cobra.Command {
 		Use:   "iso",
 		Short: "iso is used to access iso commands",
 		Long:  ``,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	isoCmd.AddCommand(isoCreate, isoDelete, isoPrivateGet, isoPrivateList, isoPublic)

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -34,7 +34,7 @@ func ISO() *cobra.Command {
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -33,7 +33,7 @@ func ISO() *cobra.Command {
 		Short: "iso is used to access iso commands",
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/iso.go
+++ b/cmd/iso.go
@@ -33,7 +33,7 @@ func ISO() *cobra.Command {
 		Short: "iso is used to access iso commands",
 		Long:  ``,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -229,6 +229,12 @@ func Kubernetes() *cobra.Command { //nolint: funlen
 		Short:   "kubernetes is used to access kubernetes commands",
 		Long:    kubernetesLong,
 		Example: kubernetesExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	kubernetesCmd.AddCommand(k8Create, k8Get, k8List, k8GetConfig, k8Update, k8Delete, k8DeleteWithResources, k8GetVersions)

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -230,7 +230,7 @@ func Kubernetes() *cobra.Command { //nolint: funlen
 		Long:    kubernetesLong,
 		Example: kubernetesExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -231,7 +231,7 @@ func Kubernetes() *cobra.Command { //nolint: funlen
 		Example: kubernetesExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -230,7 +230,7 @@ func Kubernetes() *cobra.Command { //nolint: funlen
 		Long:    kubernetesLong,
 		Example: kubernetesExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -87,7 +87,7 @@ func LoadBalancer() *cobra.Command { //nolint: funlen
 		Long:    lbLong,
 		Example: lbExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -88,7 +88,7 @@ func LoadBalancer() *cobra.Command { //nolint: funlen
 		Example: lbExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -86,6 +86,12 @@ func LoadBalancer() *cobra.Command { //nolint: funlen
 		Short:   "load balancer commands",
 		Long:    lbLong,
 		Example: lbExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	lbCmd.AddCommand(lbCreate, lbDelete, lbGet, lbList, lbUpdate)

--- a/cmd/loadBalancer.go
+++ b/cmd/loadBalancer.go
@@ -87,7 +87,7 @@ func LoadBalancer() *cobra.Command { //nolint: funlen
 		Long:    lbLong,
 		Example: lbExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -41,7 +41,7 @@ func Network() *cobra.Command {
 		Long:       netLong,
 		Deprecated: "Use vpc instead.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -40,6 +40,12 @@ func Network() *cobra.Command {
 		Short:      "network interacts with network actions",
 		Long:       netLong,
 		Deprecated: "Use vpc instead.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	networkCmd.AddCommand(networkGet, networkList, networkDelete, networkCreate)

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -41,7 +41,7 @@ func Network() *cobra.Command {
 		Long:       netLong,
 		Deprecated: "Use vpc instead.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/network.go
+++ b/cmd/network.go
@@ -42,7 +42,7 @@ func Network() *cobra.Command {
 		Deprecated: "Use vpc instead.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/objectStorage.go
+++ b/cmd/objectStorage.go
@@ -32,7 +32,7 @@ func ObjectStorageCmd() *cobra.Command {
 		Short:   "object storage commands",
 		Long:    `object-storage is used to interact with the object-storage api`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/objectStorage.go
+++ b/cmd/objectStorage.go
@@ -32,7 +32,7 @@ func ObjectStorageCmd() *cobra.Command {
 		Short:   "object storage commands",
 		Long:    `object-storage is used to interact with the object-storage api`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/objectStorage.go
+++ b/cmd/objectStorage.go
@@ -33,7 +33,7 @@ func ObjectStorageCmd() *cobra.Command {
 		Long:    `object-storage is used to interact with the object-storage api`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/objectStorage.go
+++ b/cmd/objectStorage.go
@@ -31,6 +31,12 @@ func ObjectStorageCmd() *cobra.Command {
 		Aliases: []string{"objStorage"},
 		Short:   "object storage commands",
 		Long:    `object-storage is used to interact with the object-storage api`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	objStorageCmd.AddCommand(

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -114,7 +114,7 @@ func ReservedIP() *cobra.Command {
 		Long:    reservedIPLong,
 		Example: reservedIPExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -115,7 +115,7 @@ func ReservedIP() *cobra.Command {
 		Example: reservedIPExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -114,7 +114,7 @@ func ReservedIP() *cobra.Command {
 		Long:    reservedIPLong,
 		Example: reservedIPExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/reservedIP.go
+++ b/cmd/reservedIP.go
@@ -113,6 +113,12 @@ func ReservedIP() *cobra.Command {
 		Short:   "reserved-ip lets you interact with reserved-ip ",
 		Long:    reservedIPLong,
 		Example: reservedIPExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	reservedIPCmd.AddCommand(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,8 @@ export VULTR_API_KEY='<api_key_from_vultr_account>'
 	`
 )
 
+type ctxAuthKey struct{}
+
 var cfgFile string
 var client *govultr.Client
 
@@ -121,13 +123,13 @@ func initConfig() context.Context {
 
 	if token == "" {
 		client = govultr.NewClient(nil)
-		ctx = context.WithValue(ctx, "authenticated", false)
+		ctx = context.WithValue(ctx, ctxAuthKey{}, false)
 
 	} else {
 		config := &oauth2.Config{}
 		ts := config.TokenSource(ctx, &oauth2.Token{AccessToken: token})
 		client = govultr.NewClient(oauth2.NewClient(ctx, ts))
-		ctx = context.WithValue(ctx, "authenticated", true)
+		ctx = context.WithValue(ctx, ctxAuthKey{}, true)
 	}
 
 	client.SetRateLimit(1 * time.Second)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	userAgent             = "vultr-cli/" + version
-	perPageDefault int    = 100
-	apiKeyError    string = `
+	userAgent          = "vultr-cli/" + version
+	perPageDefault int = 100
+	//nolint: gosec
+	apiKeyError string = `
 Please export your VULTR API key as an environment variable or add 'api-key' to your config file, eg:
 export VULTR_API_KEY='<api_key_from_vultr_account>'
 	`
@@ -124,7 +125,6 @@ func initConfig() context.Context {
 	if token == "" {
 		client = govultr.NewClient(nil)
 		ctx = context.WithValue(ctx, ctxAuthKey{}, false)
-
 	} else {
 		config := &oauth2.Config{}
 		ts := config.TokenSource(ctx, &oauth2.Token{AccessToken: token})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ export VULTR_API_KEY='<api_key_from_vultr_account>'
 	`
 )
 
+// ctxAuthKey is the context key for the authorized token check
 type ctxAuthKey struct{}
 
 var cfgFile string

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -33,7 +33,7 @@ func Script() *cobra.Command {
 		Short:   "startup script commands",
 		Long:    `script is used to access startup script commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -33,7 +33,7 @@ func Script() *cobra.Command {
 		Short:   "startup script commands",
 		Long:    `script is used to access startup script commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -34,7 +34,7 @@ func Script() *cobra.Command {
 		Long:    `script is used to access startup script commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -32,6 +32,12 @@ func Script() *cobra.Command {
 		Aliases: []string{"ss"},
 		Short:   "startup script commands",
 		Long:    `script is used to access startup script commands`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	cmd.AddCommand(scriptCreate, scriptGet, scriptDelete, scriptList, scriptUpdate)

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -33,7 +33,7 @@ func Snapshot() *cobra.Command {
 		Short:   "snapshot commands",
 		Long:    `snapshot is used to access snapshot commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -34,7 +34,7 @@ func Snapshot() *cobra.Command {
 		Long:    `snapshot is used to access snapshot commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -33,7 +33,7 @@ func Snapshot() *cobra.Command {
 		Short:   "snapshot commands",
 		Long:    `snapshot is used to access snapshot commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -32,6 +32,12 @@ func Snapshot() *cobra.Command {
 		Aliases: []string{"sn"},
 		Short:   "snapshot commands",
 		Long:    `snapshot is used to access snapshot commands`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	cmd.AddCommand(snapshotCreate, snapshotCreateFromURL, snapshotGet, snapshotDelete, snapshotList)

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -33,7 +33,7 @@ func SSHKey() *cobra.Command {
 		Short:   "ssh-key commands",
 		Long:    `ssh-key is used to access SSH key commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -33,7 +33,7 @@ func SSHKey() *cobra.Command {
 		Short:   "ssh-key commands",
 		Long:    `ssh-key is used to access SSH key commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -34,7 +34,7 @@ func SSHKey() *cobra.Command {
 		Long:    `ssh-key is used to access SSH key commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/sshKey.go
+++ b/cmd/sshKey.go
@@ -32,6 +32,12 @@ func SSHKey() *cobra.Command {
 		Aliases: []string{"ssh"},
 		Short:   "ssh-key commands",
 		Long:    `ssh-key is used to access SSH key commands`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	cmd.AddCommand(sshCreate, sshDelete, sshGet, sshList, sshUpdate)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -34,7 +34,7 @@ func User() *cobra.Command {
 		Long:    `user is used to access user commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -33,7 +33,7 @@ func User() *cobra.Command {
 		Short:   "user commands",
 		Long:    `user is used to access user commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -32,6 +32,12 @@ func User() *cobra.Command {
 		Aliases: []string{"u"},
 		Short:   "user commands",
 		Long:    `user is used to access user commands`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	cmd.AddCommand(userCreate, userDelete, userGet, userList, userUpdate)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -33,7 +33,7 @@ func User() *cobra.Command {
 		Short:   "user commands",
 		Long:    `user is used to access user commands`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -83,7 +83,7 @@ func VPC() *cobra.Command {
 		Long:    vpcLong,
 		Example: vpcExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -82,6 +82,12 @@ func VPC() *cobra.Command {
 		Short:   "Interact with VPCs",
 		Long:    vpcLong,
 		Example: vpcExample,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	vpcCmd.AddCommand(vpcGet, vpcList, vpcDelete, vpcCreate, vpcUpdate)

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -84,7 +84,7 @@ func VPC() *cobra.Command {
 		Example: vpcExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/vpc.go
+++ b/cmd/vpc.go
@@ -83,7 +83,7 @@ func VPC() *cobra.Command {
 		Long:    vpcLong,
 		Example: vpcExample,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -62,6 +62,12 @@ func VPC2() *cobra.Command {
 		Short:   "commands to interact with vpc2 on vultr",
 		Long:    vpc2Long,
 		Example: vpc2Example,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if auth := cmd.Context().Value("authenticated"); auth != true {
+				return fmt.Errorf(apiKeyError)
+			}
+			return nil
+		},
 	}
 
 	vpc2Cmd.AddCommand(vpc2List, vpc2Create, vpc2Info, vpc2Update, vpc2Delete)

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -64,7 +64,7 @@ func VPC2() *cobra.Command {
 		Example: vpc2Example,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if auth := cmd.Context().Value("authenticated"); auth != true {
-				return fmt.Errorf(apiKeyError)
+				return errors.New(apiKeyError)
 			}
 			return nil
 		},

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -63,7 +63,7 @@ func VPC2() *cobra.Command {
 		Long:    vpc2Long,
 		Example: vpc2Example,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
+			if !cmd.Context().Value(ctxAuthKey{}).(bool) {
 				return errors.New(apiKeyError)
 			}
 			return nil

--- a/cmd/vpc2.go
+++ b/cmd/vpc2.go
@@ -63,7 +63,7 @@ func VPC2() *cobra.Command {
 		Long:    vpc2Long,
 		Example: vpc2Example,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if auth := cmd.Context().Value("authenticated"); auth != true {
+			if cmd.Context().Value(ctxAuthKey{}).(bool) == false {
 				return errors.New(apiKeyError)
 			}
 			return nil


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
These changes re-work some of the authentication logic used to pass the API key when executing commands.  Before this, ALL commands authenticated with this key, even the `version` command.  This PR moves the client logic to allow setting a basic HTTP client without bearer tokens.  It also moves the missing API key check so that it happens in a pre-`Execute` check on each top-level command.  This check cascades down to all of its children.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
closes #359  
#332 
#92 

## Testing
* Open a new shell and do not `export VULTR_API_KEY`
* Test these commands:

- [x] `go run main.go account`
- [x] `go run main.go backups list`
- [x] `go run main.go bare-metal list`
- [x] `go run main.go billing history list`
- [x] `go run main.go block-storage list`
- [x] `go run main.go database list`
- [x] `go run main.go dns domain list`
- [x] `go run main.go firewall group list`
- [x] `go run main.go instance list`
- [x] `go run main.go iso list`
- [x] `go run main.go kubernetes list`
- [x] `go run main.go load-balancer list`
- [x] `go run main.go network list`
- [x] `go run main.go object-storage list`
- [x] `go run main.go reserved-ip list`
- [x] `go run main.go script list`
- [x] `go run main.go snapshot list`
- [x] `go run main.go ssh list`
- [x] `go run main.go user list`
- [x] `go run main.go vpc list`
- [x] `go run main.go vpc2 list`

All of which should show something along the lines of:

```
Error:
Please export your VULTR API key as an environment variable or add 'api-key' to your config file, eg:
export VULTR_API_KEY='<api_key_from_vultr_account>'

Usage:
  vultr-cli database list [flags]

Aliases:
  list, l

Examples:

        # Full example
        vultr-cli database list

        # Summarized view
        vultr-cli database list --summarize


Flags:
  -h, --help            help for list
  -l, --label string    (optional) Filter by label.
  -r, --region string   (optional) Filter by region.
      --summarize       (optional) Summarize the list output. One line per database.
  -t, --tag string      (optional) Filter by tag.

Global Flags:
      --config string   config file (default is $HOME/.vultr-cli.yaml) (default "/home/michael/.vultr-cli.yaml")

exit status 1
```

Conversely, these should still return data:

- [x] `go run main.go plans list`
- [x] `go run main.go application list`
- [x] `go run main.go os list`
- [x] `go run main.go version`

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
