### PR TITLE
Adjust DBaaS VPC pointer to detect changes

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -510,6 +510,7 @@ var databaseUpdate = &cobra.Command{
 		label, _ := cmd.Flags().GetString("label")
 		tag, _ := cmd.Flags().GetString("tag")
 		vpc, _ := cmd.Flags().GetString("vpc-id")
+		vpcSet := cmd.Flags().Lookup("vpc-id").Changed
 		maintenanceDOW, _ := cmd.Flags().GetString("maintenance-dow")
 		maintenanceTime, _ := cmd.Flags().GetString("maintenance-time")
 		clusterTimeZone, _ := cmd.Flags().GetString("cluster-time-zone")
@@ -527,7 +528,6 @@ var databaseUpdate = &cobra.Command{
 			Plan:                plan,
 			Label:               label,
 			Tag:                 tag,
-			VPCID:               govultr.StringToStringPtr(vpc),
 			MaintenanceDOW:      maintenanceDOW,
 			MaintenanceTime:     maintenanceTime,
 			ClusterTimeZone:     clusterTimeZone,
@@ -535,6 +535,10 @@ var databaseUpdate = &cobra.Command{
 			MySQLSQLModes:       mysqlSQLModes,
 			MySQLLongQueryTime:  mySQLLongQueryTime,
 			RedisEvictionPolicy: redisEvictionPolicy,
+		}
+
+		if vpcSet {
+			opt.VPCID = govultr.StringToStringPtr(vpc)
 		}
 
 		if mysqlRequirePrimaryKeySet && mysqlRequirePrimaryKey {


### PR DESCRIPTION
## Description
Current implementation on master has an issue where not including a `vpc-id` will treat it as passing an empty one, which detaches the current VPC from a Managed Database. Swaps that to only include VPCID in the update request if the value was explicitly passed, whether it is empty or not (with empty being remove VPC and an ID string setting or changing VPC).

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
