### PR TITLE
Update the bare-metal and instance tags display to use delimiters 

### DIFF
--- a/cmd/printer/bareMetal.go
+++ b/cmd/printer/bareMetal.go
@@ -8,7 +8,21 @@ func BareMetal(b *govultr.BareMetalServer) {
 	defer flush()
 
 	display(columns{"ID", "IP", "TAG", "MAC ADDRESS", "LABEL", "OS", "STATUS", "REGION", "CPU", "RAM", "DISK", "FEATURES", "TAGS"})
-	display(columns{b.ID, b.MainIP, b.Tag, b.MacAddress, b.Label, b.Os, b.Status, b.Region, b.CPUCount, b.RAM, b.Disk, b.Features, b.Tags}) //nolint:all
+	display(columns{
+		b.ID,
+		b.MainIP,
+		b.Tag,
+		b.MacAddress,
+		b.Label,
+		b.Os,
+		b.Status,
+		b.Region,
+		b.CPUCount,
+		b.RAM,
+		b.Disk,
+		arrayOfStringsToString(b.Features),
+		arrayOfStringsToString(b.Tags),
+	})
 }
 
 func BareMetalList(bms []govultr.BareMetalServer, meta *govultr.Meta) {
@@ -26,6 +40,7 @@ func BareMetalList(bms []govultr.BareMetalServer, meta *govultr.Meta) {
 		display(columns{
 			bms[i].ID,
 			bms[i].MainIP,
+			bms[i].Tag,
 			bms[i].MacAddress,
 			bms[i].Label,
 			bms[i].Os,
@@ -34,8 +49,8 @@ func BareMetalList(bms []govultr.BareMetalServer, meta *govultr.Meta) {
 			bms[i].CPUCount,
 			bms[i].RAM,
 			bms[i].Disk,
-			bms[i].Features,
-			bms[i].Tags,
+			arrayOfStringsToString(bms[i].Features),
+			arrayOfStringsToString(bms[i].Tags),
 		})
 	}
 

--- a/cmd/printer/bareMetal.go
+++ b/cmd/printer/bareMetal.go
@@ -11,7 +11,7 @@ func BareMetal(b *govultr.BareMetalServer) {
 	display(columns{
 		b.ID,
 		b.MainIP,
-		b.Tag,
+		b.Tag, //nolint: staticcheck
 		b.MacAddress,
 		b.Label,
 		b.Os,
@@ -40,7 +40,7 @@ func BareMetalList(bms []govultr.BareMetalServer, meta *govultr.Meta) {
 		display(columns{
 			bms[i].ID,
 			bms[i].MainIP,
-			bms[i].Tag,
+			bms[i].Tag, //nolint: staticcheck
 			bms[i].MacAddress,
 			bms[i].Label,
 			bms[i].Os,

--- a/cmd/printer/instance.go
+++ b/cmd/printer/instance.go
@@ -1,6 +1,8 @@
 package printer
 
-import "github.com/vultr/govultr/v3"
+import (
+	"github.com/vultr/govultr/v3"
+)
 
 func InstanceBandwidth(bandwidth *govultr.Bandwidth) {
 	display(columns{"DATE", "INCOMING BYTES", "OUTGOING BYTES"})
@@ -80,7 +82,7 @@ func InstanceList(instance []govultr.Instance, meta *govultr.Meta) {
 			instance[i].RAM,
 			instance[i].Disk,
 			instance[i].AllowedBandwidth,
-			instance[i].Tags,
+			arrayOfStringsToString(instance[i].Tags),
 		})
 	}
 
@@ -117,8 +119,8 @@ func Instance(instance *govultr.Instance) {
 	display(columns{"V6 MAIN IP", instance.V6MainIP})
 	display(columns{"V6 NETWORK", instance.V6Network})
 	display(columns{"V6 NETWORK SIZE", instance.V6NetworkSize})
-	display(columns{"FEATURES", instance.Features})
-	display(columns{"TAGS", instance.Tags})
+	display(columns{"FEATURES", arrayOfStringsToString(instance.Features)})
+	display(columns{"TAGS", arrayOfStringsToString(instance.Tags)})
 }
 
 func OsList(os []govultr.OS) {

--- a/cmd/printer/printer.go
+++ b/cmd/printer/printer.go
@@ -4,6 +4,7 @@ package printer
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/vultr/govultr/v3"
@@ -53,6 +54,19 @@ func display(values columns) {
 // displayString will `Fprintln` a string to the tabwriter
 func displayString(message string) {
 	fmt.Fprintln(tw, message)
+}
+
+// arrayOfStringsToString will build a delimited string from an array for
+// display in the printer functions.  Defaulted to comma-delimited and enclosed
+// in square brackets to maintain consistency with array Fprintf
+func arrayOfStringsToString(a []string) string {
+	delimiter := ", "
+	var sb strings.Builder
+	sb.WriteString("[")
+	sb.WriteString(strings.Join(a, delimiter))
+	sb.WriteString("]")
+
+	return sb.String()
 }
 
 // flush calls the tabwriter `Flush()` to write output


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* adds a string builder function in the printer package that formats a string in the same way that the Fprintf output used to, with the difference being that the items in the array are delimited by a comma
* uses the string builder function on the `list` and `get` command displays for bare-metal and instance

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
