### PR TITLE
Support Managed Database Read Replica Promotion

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -477,7 +477,7 @@ var databaseCreate = &cobra.Command{
 	},
 }
 
-var databaseInfo = &cobra.Command{ //nolint:dupl
+var databaseInfo = &cobra.Command{
 	Use:   "get <databaseID>",
 	Short: "get info about a specific managed database",
 	Long:  ``,
@@ -570,7 +570,7 @@ var databaseUpdate = &cobra.Command{
 	},
 }
 
-var databaseDelete = &cobra.Command{ //nolint:dupl
+var databaseDelete = &cobra.Command{
 	Use:     "delete <databaseID>",
 	Short:   "delete/destroy a managed database",
 	Aliases: []string{"destroy"},
@@ -805,7 +805,7 @@ var databaseDBDelete = &cobra.Command{
 	},
 }
 
-var databaseMaintenanceUpdatesList = &cobra.Command{ //nolint:dupl
+var databaseMaintenanceUpdatesList = &cobra.Command{
 	Use:   "list <databaseID>",
 	Short: "list all available maintenance updates for a managed database",
 	Long:  ``,
@@ -826,7 +826,7 @@ var databaseMaintenanceUpdatesList = &cobra.Command{ //nolint:dupl
 	},
 }
 
-var databaseStartMaintenance = &cobra.Command{ //nolint:dupl
+var databaseStartMaintenance = &cobra.Command{
 	Use:   "start <databaseID>",
 	Short: "Initialize maintenance updates for a managed database",
 	Long:  "",
@@ -1383,7 +1383,7 @@ var databaseAdvancedOptionsUpdate = &cobra.Command{
 	},
 }
 
-var databaseAvailableVersionsList = &cobra.Command{ //nolint:dupl
+var databaseAvailableVersionsList = &cobra.Command{
 	Use:   "list <databaseID>",
 	Short: "list all available version upgrades for a managed database",
 	Long:  ``,

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -198,7 +198,7 @@ func Database() *cobra.Command { //nolint:funlen
 		Short: "commands to handle managed database read replicas",
 		Long:  ``,
 	}
-	readReplicaCmd.AddCommand(databaseAddReadReplica)
+	readReplicaCmd.AddCommand(databaseAddReadReplica, databasePromoteReadReplica)
 	databaseAddReadReplica.Flags().StringP("region", "r", "", "region id for the new managed database read replica")
 	databaseAddReadReplica.Flags().StringP("label", "l", "", "label for the new managed database read replica")
 	databaseCmd.AddCommand(readReplicaCmd)
@@ -477,7 +477,7 @@ var databaseCreate = &cobra.Command{
 	},
 }
 
-var databaseInfo = &cobra.Command{
+var databaseInfo = &cobra.Command{ //nolint:dupl
 	Use:   "get <databaseID>",
 	Short: "get info about a specific managed database",
 	Long:  ``,
@@ -570,7 +570,7 @@ var databaseUpdate = &cobra.Command{
 	},
 }
 
-var databaseDelete = &cobra.Command{
+var databaseDelete = &cobra.Command{ //nolint:dupl
 	Use:     "delete <databaseID>",
 	Short:   "delete/destroy a managed database",
 	Aliases: []string{"destroy"},
@@ -805,7 +805,7 @@ var databaseDBDelete = &cobra.Command{
 	},
 }
 
-var databaseMaintenanceUpdatesList = &cobra.Command{
+var databaseMaintenanceUpdatesList = &cobra.Command{ //nolint:dupl
 	Use:   "list <databaseID>",
 	Short: "list all available maintenance updates for a managed database",
 	Long:  ``,
@@ -826,7 +826,7 @@ var databaseMaintenanceUpdatesList = &cobra.Command{
 	},
 }
 
-var databaseStartMaintenance = &cobra.Command{
+var databaseStartMaintenance = &cobra.Command{ //nolint:dupl
 	Use:   "start <databaseID>",
 	Short: "Initialize maintenance updates for a managed database",
 	Long:  "",
@@ -996,7 +996,28 @@ var databaseAddReadReplica = &cobra.Command{
 	},
 }
 
-var databaseGetBackupInfo = &cobra.Command{
+var databasePromoteReadReplica = &cobra.Command{
+	Use:   "promote <databaseID>",
+	Short: "Promote a read replica to its own standalone managed database",
+	Long:  "",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a databaseID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		err := client.Database.PromoteReadReplica(context.TODO(), args[0])
+		if err != nil {
+			fmt.Printf("error promoting read replica : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.DatabaseMessage("Successfully promoted read replica")
+	},
+}
+
+var databaseGetBackupInfo = &cobra.Command{ //nolint:dupl
 	Use:   "get <databaseID>",
 	Short: "Get the latest and oldest available backups for a managed database",
 	Long:  "",
@@ -1362,7 +1383,7 @@ var databaseAdvancedOptionsUpdate = &cobra.Command{
 	},
 }
 
-var databaseAvailableVersionsList = &cobra.Command{
+var databaseAvailableVersionsList = &cobra.Command{ //nolint:dupl
 	Use:   "list <databaseID>",
 	Short: "list all available version upgrades for a managed database",
 	Long:  ``,

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -1017,7 +1017,7 @@ var databasePromoteReadReplica = &cobra.Command{
 	},
 }
 
-var databaseGetBackupInfo = &cobra.Command{ //nolint:dupl
+var databaseGetBackupInfo = &cobra.Command{
 	Use:   "get <databaseID>",
 	Short: "Get the latest and oldest available backups for a managed database",
 	Long:  "",


### PR DESCRIPTION
## Description
This PR adds support for promoting Managed Databse read-only replicas to their own standalone primary subscriptions to match the functionality of the Vultr API and govultr library.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
