### PR TITLE
Add Managed Database Usage Endpoint Support

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -155,6 +155,15 @@ func Database() *cobra.Command { //nolint:funlen
 	databaseDBCreate.Flags().StringP("name", "n", "", "name of the new logical database within the manaaged database")
 	databaseCmd.AddCommand(dbCmd)
 
+	// Database usage info
+	usageCmd := &cobra.Command{
+		Use:   "usage",
+		Short: "commands to display managed database usage information",
+		Long:  ``,
+	}
+	usageCmd.AddCommand(databaseUsageInfo)
+	databaseCmd.AddCommand(usageCmd)
+
 	// Database maintenance update commands
 	maintenanceCmd := &cobra.Command{
 		Use:   "maintenance",
@@ -802,6 +811,27 @@ var databaseDBDelete = &cobra.Command{
 		}
 
 		fmt.Println("Deleted logical database")
+	},
+}
+
+var databaseUsageInfo = &cobra.Command{
+	Use:   "get <databaseID>",
+	Short: "Retrieve the current disk, memory, and CPU usage for a managed database",
+	Long:  "",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide a databaseID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		databaseUsage, _, err := client.Database.GetUsage(context.TODO(), args[0])
+		if err != nil {
+			fmt.Printf("error retrieving usage information : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.DatabaseUsageInfo(databaseUsage)
 	},
 }
 

--- a/cmd/printer/database.go
+++ b/cmd/printer/database.go
@@ -409,6 +409,28 @@ func Database(database *govultr.Database) { //nolint: funlen,gocyclo
 	}
 }
 
+// DatabaseUsageInfo will generate a printer display of disk, memory, and CPU usage for a Managed Database
+func DatabaseUsageInfo(databaseUsage *govultr.DatabaseUsage) {
+	defer flush()
+
+	display(columns{"DISK USAGE"})
+	display(columns{"CURRENT (GB)", databaseUsage.Disk.CurrentGB})
+	display(columns{"MAXIMUM (GB)", databaseUsage.Disk.MaxGB})
+	display(columns{"PERCENTAGE", databaseUsage.Disk.Percentage})
+
+	display(columns{" "})
+
+	display(columns{"MEMORY USAGE"})
+	display(columns{"CURRENT (MB)", databaseUsage.Memory.CurrentMB})
+	display(columns{"MAXIMUM (MB)", databaseUsage.Memory.MaxMB})
+	display(columns{"PERCENTAGE", databaseUsage.Memory.Percentage})
+
+	display(columns{" "})
+
+	display(columns{"CPU USAGE"})
+	display(columns{"PERCENTAGE", databaseUsage.CPU.Percentage})
+}
+
 // DatabaseUserList will generate a printer display of users within a Managed Database
 func DatabaseUserList(databaseUsers []govultr.DatabaseUser, meta *govultr.Meta) {
 	defer flush()


### PR DESCRIPTION
## Description
This PR adds support for the Managed Database usage endpoint for individual subscriptions, displaying disk, memory, and CPU usage information. Memory and CPU usage is the average over the last hour while the disk usage will always show current values.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
