### PR TITLE
Support user access control for Redis Managed Databases

### DIFF
--- a/cmd/database.go
+++ b/cmd/database.go
@@ -157,6 +157,7 @@ func Database() *cobra.Command { //nolint:funlen
 		"list of rules for individual commands")
 	databaseUserUpdateACL.Flags().StringSliceP("redis-acl-keys", "", []string{},
 		"list of key access rules")
+	databaseUserUpdateACL.MarkFlagsOneRequired("redis-acl-categories", "redis-acl-channels", "redis-acl-commands", "redis-acl-keys")
 	userCmd.AddCommand(userACLCmd)
 	databaseCmd.AddCommand(userCmd)
 

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -143,6 +143,21 @@ func Database() *cobra.Command { //nolint:funlen
 	databaseUserCreate.Flags().StringP("encryption", "e", "", "encryption type for the new managed database user (MySQL only)")
 	databaseUserUpdate.Flags().StringP("password", "p", "",
 		"new password for the manaaged database user (leave empty to generate a random secure password)")
+	userACLCmd := &cobra.Command{
+		Use:   "acl",
+		Short: "commands to handle managed database user access control (Redis only)",
+		Long:  ``,
+	}
+	userACLCmd.AddCommand(databaseUserUpdateACL)
+	databaseUserUpdateACL.Flags().StringSliceP("redis-acl-categories", "", []string{},
+		"list of rules for command categories")
+	databaseUserUpdateACL.Flags().StringSliceP("redis-acl-channels", "", []string{},
+		"list of publish/subscribe channel patterns")
+	databaseUserUpdateACL.Flags().StringSliceP("redis-acl-commands", "", []string{},
+		"list of rules for individual commands")
+	databaseUserUpdateACL.Flags().StringSliceP("redis-acl-keys", "", []string{},
+		"list of key access rules")
+	userCmd.AddCommand(userACLCmd)
 	databaseCmd.AddCommand(userCmd)
 
 	// Database logical db flags
@@ -721,6 +736,51 @@ var databaseUserDelete = &cobra.Command{
 		}
 
 		fmt.Println("Deleted managed database user")
+	},
+}
+
+var databaseUserUpdateACL = &cobra.Command{
+	Use:   "update <databaseID> <username>",
+	Short: "Update a user's access control configuration within a Redis managed database",
+	Long:  "",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return errors.New("please provide a databaseID and username")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		redisACLCategories, _ := cmd.Flags().GetStringSlice("redis-acl-categories")
+		redisACLCategoriesSet := cmd.Flags().Lookup("redis-acl-categories").Changed
+		redisACLChannels, _ := cmd.Flags().GetStringSlice("redis-acl-channels")
+		redisACLChannelsSet := cmd.Flags().Lookup("redis-acl-channels").Changed
+		redisACLCommands, _ := cmd.Flags().GetStringSlice("redis-acl-commands")
+		redisACLCommandsSet := cmd.Flags().Lookup("redis-acl-commands").Changed
+		redisACLKeys, _ := cmd.Flags().GetStringSlice("redis-acl-keys")
+		redisACLKeysSet := cmd.Flags().Lookup("redis-acl-keys").Changed
+
+		var opt = &govultr.DatabaseUserACLReq{}
+		if redisACLCategoriesSet {
+			opt.RedisACLCategories = &redisACLCategories
+		}
+		if redisACLChannelsSet {
+			opt.RedisACLChannels = &redisACLChannels
+		}
+		if redisACLCommandsSet {
+			opt.RedisACLCommands = &redisACLCommands
+		}
+		if redisACLKeysSet {
+			opt.RedisACLKeys = &redisACLKeys
+		}
+
+		// Make the request
+		databaseUser, _, err := client.Database.UpdateUserACL(context.TODO(), args[0], args[1], opt)
+		if err != nil {
+			fmt.Printf("error updating managed database user access control : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.DatabaseUser(*databaseUser)
 	},
 }
 

--- a/cmd/printer/database.go
+++ b/cmd/printer/database.go
@@ -447,6 +447,13 @@ func DatabaseUserList(databaseUsers []govultr.DatabaseUser, meta *govultr.Meta) 
 		if databaseUsers[u].Encryption != "" {
 			display(columns{"ENCRYPTION", databaseUsers[u].Encryption})
 		}
+		if databaseUsers[u].AccessControl != nil {
+			display(columns{"ACCESS CONTROL"})
+			display(columns{"REDIS ACL CATEGORIES", databaseUsers[u].AccessControl.RedisACLCategories})
+			display(columns{"REDIS ACL CHANNELS", databaseUsers[u].AccessControl.RedisACLChannels})
+			display(columns{"REDIS ACL COMMANDS", databaseUsers[u].AccessControl.RedisACLCommands})
+			display(columns{"REDIS ACL KEYS", databaseUsers[u].AccessControl.RedisACLKeys})
+		}
 		display(columns{"---------------------------"})
 	}
 
@@ -461,6 +468,13 @@ func DatabaseUser(databaseUser govultr.DatabaseUser) {
 	display(columns{"PASSWORD", databaseUser.Password})
 	if databaseUser.Encryption != "" {
 		display(columns{"ENCRYPTION", databaseUser.Encryption})
+	}
+	if databaseUser.AccessControl != nil {
+		display(columns{"ACCESS CONTROL"})
+		display(columns{"REDIS ACL CATEGORIES", databaseUser.AccessControl.RedisACLCategories})
+		display(columns{"REDIS ACL CHANNELS", databaseUser.AccessControl.RedisACLChannels})
+		display(columns{"REDIS ACL COMMANDS", databaseUser.AccessControl.RedisACLCommands})
+		display(columns{"REDIS ACL KEYS", databaseUser.AccessControl.RedisACLKeys})
 	}
 }
 


### PR DESCRIPTION
## Description
This PR adds support for Redis user access control configurations for Managed Databases. There are updates to the list and get endpoints to retrieve the current configuration when applicable as well as added support for pushing updates to the current ACL configuration under the nested `database user acl update <databaseID> <username> --flags` structure.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
