### PR TITLE
Support Marketplace App Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Available Commands:
   iso                iso is used to access iso commands
   kubernetes         kubernetes is used to access kubernetes commands
   load-balancer      load balancer commands
+  marketplace        Commands to interact with Vultr Marketplace
   object-storage     object storage commands
   os                 os is used to access os commands
   plans              get information about Vultr plans

--- a/cmd/bareMetal.go
+++ b/cmd/bareMetal.go
@@ -152,6 +152,14 @@ func BareMetal() *cobra.Command {
 	bareMetalCreate.Flags().StringP("ripv4", "v", "", "(optional) IP address of the floating IP to use as the main IP of this server.")
 	bareMetalCreate.Flags().BoolP("persistent_pxe", "x", false, "enable persistent_pxe | true or false")
 
+	var appVariables map[string]string
+	bareMetalCreate.Flags().StringToStringVar(
+		&appVariables,
+		"app-variables",
+		nil,
+		"Map containing list of user-supplied variables for a marketplace app",
+	)
+
 	bareMetalList.Flags().StringP("cursor", "c", "", "(optional) Cursor for paging.")
 	bareMetalList.Flags().IntP(
 		"per-page",
@@ -218,6 +226,7 @@ var bareMetalCreate = &cobra.Command{
 		ripv4, _ := cmd.Flags().GetString("ripv4")
 		pxe, _ := cmd.Flags().GetBool("persistent_pxe")
 		image, _ := cmd.Flags().GetString("image")
+		appVariables, _ := cmd.Flags().GetStringToString("app-variables")
 
 		options := &govultr.BareMetalCreate{
 			StartupScriptID: script,
@@ -246,6 +255,10 @@ var bareMetalCreate = &cobra.Command{
 
 		if ipv6 == "yes" {
 			options.EnableIPv6 = govultr.BoolToBoolPtr(true)
+		}
+
+		if appVariables != nil {
+			options.AppVariables = appVariables
 		}
 
 		osOptions := map[string]interface{}{"app_id": app, "snapshot_id": snapshot, "os_id": osID, "image_id": image}

--- a/cmd/database.go
+++ b/cmd/database.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Vultr-cli Authors
+// Copyright © 2023 The Vultr-cli Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -205,6 +205,14 @@ func Instance() *cobra.Command { //nolint: funlen,gocyclo
 	instanceCreate.Flags().StringSliceP("tags", "", []string{}, "A comma-separated list of tags to assign to this instance")
 	instanceCreate.Flags().StringP("firewall-group", "", "", "The firewall group to assign to this instance")
 
+	var appVariables map[string]string
+	instanceCreate.Flags().StringToStringVar(
+		&appVariables,
+		"app-variables",
+		nil,
+		"Map containing list of user-supplied variables for a marketplace app",
+	)
+
 	instanceList.Flags().StringP("cursor", "c", "", "(optional) Cursor for paging.")
 	instanceList.Flags().IntP(
 		"per-page",
@@ -1289,6 +1297,7 @@ var instanceCreate = &cobra.Command{
 		tag, _ := cmd.Flags().GetString("tag")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
 		fwg, _ := cmd.Flags().GetString("firewall-group")
+		appVariables, _ := cmd.Flags().GetStringToString("app-variables")
 
 		osOptions := map[string]interface{}{"iso_id": iso, "os_id": osID, "app_id": app, "snapshot_id": snapshot, "image_id": image}
 
@@ -1356,6 +1365,9 @@ var instanceCreate = &cobra.Command{
 		}
 		if userData != "" {
 			opt.UserData = base64.StdEncoding.EncodeToString([]byte(userData))
+		}
+		if appVariables != nil {
+			opt.AppVariables = appVariables
 		}
 
 		instance, _, err := client.Instance.Create(context.TODO(), opt)

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -1,0 +1,88 @@
+// Copyright © 2023 The Vultr-cli Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/vultr/vultr-cli/v2/cmd/printer"
+)
+
+var (
+	marketplaceLong    = `Get commands available to marketplace`
+	marketplaceExample = `
+	# Full example
+	vultr-cli marketplace
+	`
+	marketplaceAppLong    = `Get commands available to marketplace apps`
+	marketplaceAppExample = `
+	# Full example
+	vultr-cli marketplace app
+	`
+	marketplaceListAppVariableLong    = `List all user-supplied variables for a given Vultr Marketplace app`
+	marketplaceListAppVariableExample = `
+	# Full example
+	vultr-cli marketplace app list-variables exampleapp
+	`
+)
+
+// Marketplace represents the marketplace command
+func Marketplace() *cobra.Command { //nolint:funlen
+	marketplaceCmd := &cobra.Command{
+		Use:     "marketplace",
+		Short:   "commands to interact with the vultr marketplace",
+		Long:    marketplaceLong,
+		Example: marketplaceExample,
+	}
+
+	// App flags
+	marketplaceAppCmd := &cobra.Command{
+		Use:     "app",
+		Short:   "commands to interact with vultr marketplace apps",
+		Long:    marketplaceAppLong,
+		Example: marketplaceAppExample,
+	}
+	marketplaceAppCmd.AddCommand(marketplaceAppVariableList)
+	marketplaceCmd.AddCommand(marketplaceAppCmd)
+
+	return marketplaceCmd
+}
+
+var marketplaceAppVariableList = &cobra.Command{
+	Use:     "list-variables",
+	Aliases: []string{"l"},
+	Short:   "list all user-supplied variables for a marketplace app",
+	Long:    marketplaceListAppVariableLong,
+	Example: marketplaceListAppVariableExample,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("please provide an imageID")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		s, _, err := client.Marketplace.ListAppVariables(context.TODO(), args[0])
+		if err != nil {
+			fmt.Printf("error getting list of marketplace app variables : %v\n", err)
+			os.Exit(1)
+		}
+
+		printer.MarketplaceAppVariableList(s)
+	},
+}

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -43,7 +43,7 @@ var (
 )
 
 // Marketplace represents the marketplace command
-func Marketplace() *cobra.Command { //nolint:funlen
+func Marketplace() *cobra.Command {
 	marketplaceCmd := &cobra.Command{
 		Use:     "marketplace",
 		Short:   "commands to interact with the vultr marketplace",

--- a/cmd/printer/marketplace.go
+++ b/cmd/printer/marketplace.go
@@ -1,0 +1,22 @@
+package printer
+
+import (
+	"github.com/vultr/govultr/v3"
+)
+
+// MarketplaceAppVariableList will generate a printer display of user-supplied variables for a Vultr Marketplace app
+func MarketplaceAppVariableList(appVariables []govultr.MarketplaceAppVariable) {
+	defer flush()
+
+	if len(appVariables) == 0 {
+		displayString("This app contains no user-supplied variables")
+		return
+	}
+
+	for p := range appVariables {
+		display(columns{"NAME", appVariables[p].Name})
+		display(columns{"DESCRIPTION", appVariables[p].Description})
+		display(columns{"TYPE", *appVariables[p].Required})
+		display(columns{"---------------------------"})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func init() {
 	rootCmd.AddCommand(ISO())
 	rootCmd.AddCommand(Kubernetes())
 	rootCmd.AddCommand(LoadBalancer())
+	rootCmd.AddCommand(Marketplace())
 	rootCmd.AddCommand(Network())
 	rootCmd.AddCommand(Os())
 	rootCmd.AddCommand(ObjectStorageCmd())


### PR DESCRIPTION
## Description
This PR updates Vultr-CLI to support user-supplied variables for Vultr Marketplace apps. First is the marketplace/app commands in order to facilitate a public/no-auth list variables endpoint. This updates also contains a new flag for including app variables on create for VPS instances and bare metal servers.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
