### PR TITLE
Remove shorthand flag output on kubernetes

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -520,7 +520,7 @@ required in node pool. Use / between each new node pool.  E.g:
 		},
 	}
 
-	config.Flags().StringP("output-file", "o", "", "(optional) the file path to write kubeconfig to")
+	config.Flags().StringP("output-file", "", "", "(optional) the file path to write kubeconfig to")
 
 	// Versions
 	versions := &cobra.Command{


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Resolve the crash because of overlapping on the `-o` flag shorthand on the `kubernetes` command.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
