### PR TITLE
Add node labels to kubernetes node pools

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -27,11 +27,11 @@ var (
 	createLong    = `Create kubernetes cluster on your Vultr account`
 	createExample = `
 	# Full Example
-	vultr-cli kubernetes create --label="my-cluster" --region="ewr" --version="v1.29.1+1" \
+	vultr-cli kubernetes create --label="my-cluster" --region="ewr" --version="v1.29.2+1" \
 		--node-pools="quantity:3,plan:vc2-2c-4gb,label:my-nodepool,tag:my-tag"
 
 	# Shortened with alias commands
-	vultr-cli k c -l="my-cluster" -r="ewr" -v="v1.29.1+1" -n="quantity:3,plan:vc2-2c-4gb,label:my-nodepool,tag:my-tag"
+	vultr-cli k c -l="my-cluster" -r="ewr" -v="v1.29.2+1" -n="quantity:3,plan:vc2-2c-4gb,label:my-nodepool,tag:my-tag"
 	`
 
 	getLong    = `Get a single kubernetes cluster from your account`
@@ -61,7 +61,7 @@ var (
 	updateLong    = `Update a specific kubernetes cluster on your Vultr Account`
 	updateExample = `
 	# Full example
-	vultr-cli kubernetes update ffd31f18-5f77-454c-9065-212f942c3c35 --label="updated-label"
+	vultr-cli kubernetes update ffd31f18-5f77-454c-9065-212f942c3c35 --label="updated-label" 
 
 	# Shortened with alias commands
 	vultr-cli k u ffd31f18-5f77-454c-9065-212f942c3c35 -l="updated-label"
@@ -81,14 +81,14 @@ var (
 	getConfigLong    = `Returns a base64 encoded config of a specified kubernetes cluster on your Vultr Account`
 	getConfigExample = `
 	
-		# Full example
-		vultr-cli kubernetes config ffd31f18-5f77-454c-9065-212f942c3c35
-		vultr-cli kubernetes config ffd31f18-5f77-454c-9065-212f942c3c35 --output-file /your/path/
-	
-		# Shortened with alias commands
-		vultr-cli k config ffd31f18-5f77-454c-9065-212f942c3c35
-		vultr-cli k config  ffd31f18-5f77-454c-9065-212f942c3c35 -o /your/path/
-		`
+	# Full example
+	vultr-cli kubernetes config ffd31f18-5f77-454c-9065-212f942c3c35
+	vultr-cli kubernetes config ffd31f18-5f77-454c-9065-212f942c3c35 --output-file /your/path/
+
+	# Shortened with alias commands
+	vultr-cli k config ffd31f18-5f77-454c-9065-212f942c3c35
+	vultr-cli k config  ffd31f18-5f77-454c-9065-212f942c3c35 -o /your/path/
+	`
 
 	getVersionsLong    = `Returns a list of supported kubernetes versions you can deploy`
 	getVersionsExample = `
@@ -120,10 +120,10 @@ var (
 	upgradeLong    = `Initiate an upgrade of the kubernetes version on a given cluster`
 	upgradeExample = `
 	# Full example
-	vultr-cli kubernetes upgrades start d4908765-b82a-4e7d-83d9-c0bc4c6a36d0 --version="v1.23.5+3"
+	vultr-cli kubernetes upgrades start d4908765-b82a-4e7d-83d9-c0bc4c6a36d0 --version="v1.29.2+1"
 
 	# Shortened with alias commands
-	vultr-cli k e s d4908765-b82a-4e7d-83d9-c0bc4c6a36d0 -v="v1.23.5+3"
+	vultr-cli k e s d4908765-b82a-4e7d-83d9-c0bc4c6a36d0 -v="v1.29.2+1"
 	`
 
 	nodepoolLong    = `Get all available commands for Kubernetes node pools`
@@ -138,7 +138,8 @@ var (
 	createNPLong    = `Create node pool for your kubernetes cluster on your Vultr account`
 	createNPExample = `
 	# Full Example
-	vultr-cli kubernetes node-pool create ffd31f18-5f77-454c-9064-212f942c3c34 --label="nodepool" --quantity=3  --plan="vc2-1c-2gb"
+	vultr-cli kubernetes node-pool create ffd31f18-5f77-454c-9064-212f942c3c34 --label="nodepool" --quantity=3  \
+		--plan="vc2-1c-2gb" --node-labels="application=id-service,environment=development"
 
 	# Shortened with alias commands
 	vultr-cli k n c ffd31f18-5f77-454c-9064-212f942c3c34 -l="nodepool" -q=3  -p="vc2-1c-2gb"
@@ -167,7 +168,8 @@ var (
 	updateNPLong    = `Update a specific node pool in a kubernetes cluster on your Vultr Account`
 	updateNPExample = `
 	# Full example
-	vultr-cli kubernetes node-pool update ffd31f18-5f77-454c-9064-212f942c3c34 abd31f18-3f77-454c-9064-212f942c3c34 --quantity=4
+	vultr-cli kubernetes node-pool update ffd31f18-5f77-454c-9064-212f942c3c34 abd31f18-3f77-454c-9064-212f942c3c34 --quantity=4 \
+		--node-labels="application=id-service,environment=development"
 
 	# Shortened with alias commands
 	vultr-cli k n u ffd31f18-5f77-454c-9065-212f942c3c35 abd31f18-3f77-454c-9064-212f942c3c34 --q=4
@@ -802,7 +804,7 @@ required in node pool. Use / between each new node pool.  E.g:
 	npCreate.Flags().BoolP("auto-scaler", "", false, "Enable the auto scaler with your cluster")
 	npCreate.Flags().IntP("min-nodes", "", 1, "Minimum nodes for auto scaler")
 	npCreate.Flags().IntP("max-nodes", "", 1, "Maximum nodes for auto scaler")
-	npCreate.Flags().StringToString("node-labels", nil, "A key=value comma separated string of labels to apply to the nodes in this nodepool")
+	npCreate.Flags().StringToString("node-labels", nil, "A key=value comma separated string of labels to apply to the nodes in this node pool")
 
 	// Node Pool Update
 	npUpdate := &cobra.Command{
@@ -896,7 +898,7 @@ required in node pool. Use / between each new node pool.  E.g:
 	npUpdate.Flags().BoolP("auto-scaler", "", false, "Enable the auto scaler with your cluster")
 	npUpdate.Flags().IntP("min-nodes", "", 1, "Minimum nodes for auto scaler")
 	npUpdate.Flags().IntP("max-nodes", "", 1, "Maximum nodes for auto scaler")
-	npUpdate.Flags().StringToString("node-labels", nil, "A key=value comma separated string of labels to apply to the nodes in this nodepool")
+	npUpdate.Flags().StringToString("node-labels", nil, "A key=value comma separated string of labels to apply to the nodes in this node pool")
 
 	npUpdate.MarkFlagsOneRequired("quantity", "tag", "auto-scaler", "min-nodes", "max-nodes", "node-labels")
 

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -26,13 +26,31 @@ var (
 
 	createLong    = `Create kubernetes cluster on your Vultr account`
 	createExample = `
-	# Full Example
+	# Full example
 	vultr-cli kubernetes create --label="my-cluster" --region="ewr" --version="v1.29.2+1" \
 		--node-pools="quantity:3,plan:vc2-2c-4gb,label:my-nodepool,tag:my-tag"
 
 	# Shortened with alias commands
 	vultr-cli k c -l="my-cluster" -r="ewr" -v="v1.29.2+1" -n="quantity:3,plan:vc2-2c-4gb,label:my-nodepool,tag:my-tag"
-	`
+
+	# Node pool options
+	The --node-pools option allows you to pass in options for any number of
+	node pools when creating a cluster. The options are passed in a delimited
+	string.  Different node pools are delimited by a slash (/). The options for
+	each node pool are delimited by a comma (,) and each option is defined by
+	colon (:).  If provided, the node pool options can also parse out the
+	node-labels params which are delimited by a pipe (|).
+
+	Available options are documented in the 'kubernetes node-pool create --help' 
+
+	For example:
+
+	Multiple node pools
+	--node-pools="quantity:1,plan:vc2-4c-8gb,label:main-node-pool/quantity:5,plan:vc2-2c-4gb,label:worker-pool,auto-scaler:true,min-nodes:5,max-nodes:10"
+
+	Using node labels 
+	--node-pools="quantity:5,plan:vc2-2c-4gb,label:worker-pool,auto-scaler:true,min-nodes:5,max-nodes:10,node-labels:application=identity-service|worker-size=small"
+	` //nolint:lll
 
 	getLong    = `Get a single kubernetes cluster from your account`
 	getExample = `

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -24,7 +24,8 @@ var (
 	vultr-cli kubernetes
 	`
 
-	createLong    = `Create kubernetes cluster on your Vultr account`
+	createLong = `Create kubernetes cluster on your Vultr account`
+	//nolint:lll
 	createExample = `
 	# Full example
 	vultr-cli kubernetes create --label="my-cluster" --region="ewr" --version="v1.29.2+1" \
@@ -50,7 +51,7 @@ var (
 
 	Using node labels 
 	--node-pools="quantity:5,plan:vc2-2c-4gb,label:worker-pool,auto-scaler:true,min-nodes:5,max-nodes:10,node-labels:application=identity-service|worker-size=small"
-	` //nolint:lll
+	`
 
 	getLong    = `Get a single kubernetes cluster from your account`
 	getExample = `
@@ -1056,7 +1057,7 @@ Optionally you can include tag, node-labels, auto-scaler, min-nodes and max-node
 }
 
 // formatNodeData loops over the parse strings for a node and returns the formatted struct
-func formatNodeData(node []string) (*govultr.NodePoolReq, error) {
+func formatNodeData(node []string) (*govultr.NodePoolReq, error) { //nolint:gocyclo
 	nodeData := &govultr.NodePoolReq{}
 	for _, f := range node {
 		nodeDataKeyVal := strings.Split(f, ":")

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -1019,10 +1019,10 @@ func formatNodePools(nodePools []string) ([]govultr.NodePoolReq, error) {
 	for _, r := range npList {
 		nodeData := strings.Split(r, ",")
 
-		if len(nodeData) < 3 || len(nodeData) > 7 {
+		if len(nodeData) < 3 || len(nodeData) > 8 {
 			return nil, fmt.Errorf(
 				`unable to format node pool. each node pool must include label, quantity, and plan.
-				Optionally you can include tag, auto-scaler, min-nodes and max-nodes`,
+Optionally you can include tag, node-labels, auto-scaler, min-nodes and max-nodes`,
 			)
 		}
 
@@ -1063,6 +1063,8 @@ func formatNodeData(node []string) (*govultr.NodePoolReq, error) {
 			nodeData.Label = val
 		case field == "tag":
 			nodeData.Tag = val
+		case field == "node-labels":
+			nodeData.Labels = formatNodeLabels(val)
 		case field == "auto-scaler":
 			v, err := strconv.ParseBool(val)
 			if err != nil {
@@ -1085,6 +1087,19 @@ func formatNodeData(node []string) (*govultr.NodePoolReq, error) {
 	}
 
 	return nodeData, nil
+}
+
+// formatNodeLabels parses the node-labels option from the cluster create nodepool formatted string
+func formatNodeLabels(nl string) map[string]string {
+	data := make(map[string]string)
+	labels := strings.Split(nl, "|")
+
+	for i := range labels {
+		label := strings.Split(labels[i], "=")
+		data[label[0]] = label[1]
+	}
+
+	return data
 }
 
 type options struct {

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -747,6 +747,11 @@ required in node pool. Use / between each new node pool.  E.g:
 				return fmt.Errorf("error parsing flag 'max-nodes' for kubernetes cluster node pool create : %v", errMa)
 			}
 
+			npLabels, errNl := cmd.Flags().GetStringToString("node-labels")
+			if errNl != nil {
+				return fmt.Errorf("error parsing flag 'node-labels' for kubernetes cluster node pool create : %v", errNl)
+			}
+
 			o.npCreateReq = &govultr.NodePoolReq{
 				NodeQuantity: quantity,
 				Label:        label,
@@ -755,6 +760,7 @@ required in node pool. Use / between each new node pool.  E.g:
 				AutoScaler:   govultr.BoolToBoolPtr(false),
 				MinNodes:     minNodes,
 				MaxNodes:     maxNodes,
+				Labels:       npLabels,
 			}
 
 			if autoscaler {
@@ -796,6 +802,7 @@ required in node pool. Use / between each new node pool.  E.g:
 	npCreate.Flags().BoolP("auto-scaler", "", false, "Enable the auto scaler with your cluster")
 	npCreate.Flags().IntP("min-nodes", "", 1, "Minimum nodes for auto scaler")
 	npCreate.Flags().IntP("max-nodes", "", 1, "Maximum nodes for auto scaler")
+	npCreate.Flags().StringToString("node-labels", nil, "A key=value comma separated string of labels to apply to the nodes in this nodepool")
 
 	// Node Pool Update
 	npUpdate := &cobra.Command{
@@ -836,6 +843,11 @@ required in node pool. Use / between each new node pool.  E.g:
 				return fmt.Errorf("error parsing flag 'max-nodes' for kubernetes cluster node pool update : %v", errMa)
 			}
 
+			npLabels, errNl := cmd.Flags().GetStringToString("node-labels")
+			if errNl != nil {
+				return fmt.Errorf("error parsing flag 'node-labels' for kubernetes cluster node pool update : %v", errNl)
+			}
+
 			o.npUpdateReq = &govultr.NodePoolReqUpdate{}
 
 			if cmd.Flags().Changed("quantity") {
@@ -856,6 +868,10 @@ required in node pool. Use / between each new node pool.  E.g:
 
 			if cmd.Flags().Changed("max-nodes") {
 				o.npUpdateReq.MaxNodes = maxNodes
+			}
+
+			if cmd.Flags().Changed("node-labels") {
+				o.npUpdateReq.Labels = npLabels
 			}
 
 			np, err := o.nodePoolUpdate()
@@ -880,8 +896,9 @@ required in node pool. Use / between each new node pool.  E.g:
 	npUpdate.Flags().BoolP("auto-scaler", "", false, "Enable the auto scaler with your cluster")
 	npUpdate.Flags().IntP("min-nodes", "", 1, "Minimum nodes for auto scaler")
 	npUpdate.Flags().IntP("max-nodes", "", 1, "Maximum nodes for auto scaler")
+	npUpdate.Flags().StringToString("node-labels", nil, "A key=value comma separated string of labels to apply to the nodes in this nodepool")
 
-	npUpdate.MarkFlagsOneRequired("quantity", "tag", "auto-scaler", "min-nodes", "max-nodes")
+	npUpdate.MarkFlagsOneRequired("quantity", "tag", "auto-scaler", "min-nodes", "max-nodes", "node-labels")
 
 	// Node Pool Delete
 	npDelete := &cobra.Command{

--- a/cmd/kubernetes/printer.go
+++ b/cmd/kubernetes/printer.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/vultr/govultr/v3"
@@ -132,6 +133,9 @@ func (c *ClustersPrinter) Data() [][]string {
 				[]string{"AUTO SCALER", strconv.FormatBool(c.Clusters[i].NodePools[j].AutoScaler)},
 				[]string{"MIN NODES", strconv.Itoa(c.Clusters[i].NodePools[j].MinNodes)},
 				[]string{"MAX NODES", strconv.Itoa(c.Clusters[i].NodePools[j].MaxNodes)},
+			)
+
+			data = append(data,
 				[]string{" "},
 				[]string{"NODES"},
 			)
@@ -150,6 +154,14 @@ func (c *ClustersPrinter) Data() [][]string {
 						c.Clusters[i].NodePools[j].Nodes[k].Status,
 					},
 				)
+			}
+
+			if len(c.Clusters[i].NodePools[j].Labels) != 0 {
+				data = append(data, []string{" "}, []string{"NODE LABELS"})
+				for k := range c.Clusters[i].NodePools[j].Labels {
+					label := fmt.Sprintf("%s=%s", k, c.Clusters[i].NodePools[j].Labels[k])
+					data = append(data, []string{label})
+				}
 			}
 
 			data = append(data, []string{" "})
@@ -239,6 +251,14 @@ func (c *ClusterPrinter) Data() [][]string {
 			)
 		}
 
+		if len(c.Cluster.NodePools[i].Labels) != 0 {
+			data = append(data, []string{" "}, []string{"NODE LABELS"})
+			for k := range c.Cluster.NodePools[i].Labels {
+				label := fmt.Sprintf("%s=%s", k, c.Cluster.NodePools[i].Labels[k])
+				data = append(data, []string{label})
+			}
+		}
+
 		data = append(data, []string{" "})
 	}
 
@@ -314,6 +334,14 @@ func (n *NodePoolsPrinter) Data() [][]string {
 				},
 			)
 		}
+
+		if len(n.NodePools[i].Labels) != 0 {
+			data = append(data, []string{" "}, []string{"NODE LABELS"})
+			for k := range n.NodePools[i].Labels {
+				label := fmt.Sprintf("%s=%s", k, n.NodePools[i].Labels[k])
+				data = append(data, []string{label})
+			}
+		}
 	}
 
 	return data
@@ -379,6 +407,14 @@ func (n *NodePoolPrinter) Data() [][]string {
 				n.NodePool.Nodes[i].Status,
 			},
 		)
+	}
+
+	if len(n.NodePool.Labels) != 0 {
+		data = append(data, []string{" "}, []string{"NODE LABELS"})
+		for k := range n.NodePool.Labels {
+			label := fmt.Sprintf("%s=%s", k, n.NodePool.Labels[k])
+			data = append(data, []string{label})
+		}
 	}
 
 	return data


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
This PR will add flags and printer output to support node labels in a node pool on create and update via the `--node-labels` flag.

## Test examples
### Check the helptext
```sh
go run main.go kubenetes create --help
```
And
```sh
go run main.go kubenetes node-pool create --help
```
### Create a cluster with `node-labels` in the node pool options
```sh
 go run main.go kubernetes create --label=cli-flags-test --region="ord" --version="v1.29.2+1" --node-pools="quantity:5,plan:vc2-2c-4gb,label:worker-pool,auto-scaler:true,min-nodes:5,max-nodes:10,node-labels:application=identity-service|worker-size=small"
 ```
 You'll see some output in the new printer that should show the `NODE LABELS` like
 ```
 ID                      8aa47e02-93ea-4caf-be17-28875d79aab0
LABEL                   cli-flags-test
DATE CREATED            2024-03-11T16:45:21+00:00
CLUSTER SUBNET          10.244.0.0/16
SERVICE SUBNET          10.96.0.0/12
IP                      0.0.0.0
ENDPOINT                8aa47e02-93ea-4caf-be17-28875d79aab0.vultr-k8s.com
HIGH AVAIL              false
FIREWALL GROUP ID
VERSION                 v1.29.2+1
REGION                  ord
STATUS                  pending

NODE POOLS
ID              a7604057-e77a-43c3-964b-8b1500ca47e5
DATE CREATED    2024-03-11T16:45:22+00:00
DATE UPDATED    2024-03-11T16:45:29+00:00
LABEL           worker-pool
TAG
PLAN            vc2-2c-4gb
STATUS          pending
NODE QUANTITY   5
AUTO SCALER     true
MIN NODES       5
MAX NODES       10

NODES
ID                                      DATE CREATED                    LABEL                           STATUS
e67a1c96-7053-459e-a223-d25b764539ca    2024-03-11T16:45:22+00:00       worker-pool-6e205ba343c1        pending
7c90c559-9355-44f9-a6c1-01fc9fb3a54d    2024-03-11T16:45:23+00:00       worker-pool-31beaf0b119a        pending
f802609d-a73e-41cd-a10b-00fc370abc1c    2024-03-11T16:45:25+00:00       worker-pool-2b2167de1209        pending
fcb6305f-70eb-4981-848e-12c2dee046cc    2024-03-11T16:45:26+00:00       worker-pool-288ba7da6f2a        pending
c90bbd98-22bc-4e29-b1f9-0a154fdcdadd    2024-03-11T16:45:28+00:00       worker-pool-9a7f98894a86        pending

NODE LABELS
worker-size=small
application=identity-service
```
### Create a new node pool on an existing cluster with the `--node-labels` flag
```sh
go run main.go kubernetes node-pool create 8aa47e02-93ea-4caf-be17-28875d79aab0 --plan="vc2-1c-2gb" --quantity=3 --label="second-np" --auto-scaler=true --min-nodes=1 --max-nodes=3 --node-labels="application=relay-service,worker-size=tiny"
```
And you should see something like:
```
ID              47734a62-6146-7747-5337-436f2b554852
DATE CREATED    2024-03-11T17:04:06+00:00
DATE UPDATED    2024-03-11T17:04:10+00:00
LABEL           second-np
TAG
PLAN            vc2-1c-2gb
STATUS          pending
NODE QUANTITY   3
AUTO SCALER     true
MIN NODES       1
MAX NODES       3

NODES
ID                                      DATE CREATED                    LABEL                   STATUS
58824dbe-e9fe-483b-aeb1-1135c122a7ca    2024-03-11T17:04:06+00:00       second-np-1e0d1fceadf6  pending
b9a6583c-3f29-47ce-89ce-7a511f0c4689    2024-03-11T17:04:07+00:00       second-np-b33dd2038272  pending
ad8d7561-4e1e-49c6-96df-0fe312bef8d9    2024-03-11T17:04:09+00:00       second-np-057b068f2158  pending

NODE LABELS
application=relay-service
worker-size=tiny
```

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
