### PR TITLE
Fix incorrect govultr delete method for VPC2

### DIFF
--- a/cmd/vpc2/vpc2.go
+++ b/cmd/vpc2/vpc2.go
@@ -422,5 +422,5 @@ func (o *options) detachNodes() error {
 }
 
 func (o *options) del() error {
-	return o.Base.Client.VPC.Delete(o.Base.Context, o.Base.Args[0])
+	return o.Base.Client.VPC2.Delete(o.Base.Context, o.Base.Args[0])
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Fix incorrect govultr delete method for VPC2.  Previously this error was thrown on any and all VPC2 deletes:
```
Error: error deleting vpc2 : {"error":"Invalid private network ID.","status":404}
exit status 1
````

## Testing instructions
Make sure a VPC2 can be deleted
```
go run main.go vpc2 delete UUID_HERE
```

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #424 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
