### PR TITLE
fix mistyped persistent_pxe baremetal flag

### DIFF
--- a/cmd/baremetal/baremetal.go
+++ b/cmd/baremetal/baremetal.go
@@ -1145,9 +1145,9 @@ func parseCreateFlags(cmd *cobra.Command) (*govultr.BareMetalCreate, error) { //
 		return nil, fmt.Errorf("error parsing ripv4 flag for bare metal create : %v", err)
 	}
 
-	pxe, err := cmd.Flags().GetBool("persistenterrpxe")
+	pxe, err := cmd.Flags().GetBool("persistent_pxe")
 	if err != nil {
-		return nil, fmt.Errorf("error parsing persistenterrpxe flag for bare metal create : %v", err)
+		return nil, fmt.Errorf("error parsing persistent_pxe flag for bare metal create : %v", err)
 	}
 
 	image, err := cmd.Flags().GetString("image")


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
before:
```
$ vultr-cli bare-metal create -r ewr -p vbm-24c-256gb-amd --os=1743
Error: error parsing flags for bare metal create : error parsing persistenterrpxe flag for bare metal create : flag accessed but not defined: persistenterrpxe
```
after:
```
$ ./builds/vultr-cli_linux_amd64 bare-metal create -r ewr -p vbm-24c-256gb-amd --os=1743
Error: error with bare metal create : {"error":"Server add failed: This plan is currently unavailable in this region. Please choose a different plan.","status":400}
```

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
