### PR TITLE
Fix error when a config file is not present

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,10 +65,12 @@ func Execute() {
 }
 
 func init() {
+	configPath := configHome()
+
 	// init the config file with viper
 	initConfig()
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", configHome(), "config file (default is $HOME/.vultr-cli.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", configPath, "config file (default is $HOME/.vultr-cli.yaml)")
 	if err := viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config")); err != nil {
 		fmt.Printf("error binding root pflag 'config': %v\n", err)
 	}
@@ -115,7 +117,7 @@ func init() {
 	)
 }
 
-// initConfig reads in config file and ENV variables if set.
+// initConfig reads in config file to viper if it exists
 func initConfig() {
 	configPath := viper.GetString("config")
 
@@ -137,9 +139,10 @@ func initConfig() {
 }
 
 func configHome() string {
-	// check for a config file at ~/.config/vultr-cli.yaml
+	// check for a config file in the user config directory
 	configFolder, errConfig := os.UserConfigDir()
 	if errConfig != nil {
+		fmt.Printf("Unable to determine default user config directory : %v", errConfig)
 		os.Exit(1)
 	}
 
@@ -152,6 +155,7 @@ func configHome() string {
 	// check for a config file at ~/.vultr-cli.yaml
 	configFolder, errHome := os.UserHomeDir()
 	if errHome != nil {
+		fmt.Printf("Unable to check user config in home directory: %v", errHome)
 		os.Exit(1)
 	}
 
@@ -160,6 +164,7 @@ func configHome() string {
 		// if it doesn't exist, create one
 		f, err := os.Create(filepath.Clean(configFile))
 		if err != nil {
+			fmt.Printf("Unable to create default config file : %v", err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Move config file checks before reading in the default file.

## Testing
* Make sure you don't already have a config file somewhere (usually $HOME/.vultr-cli.yaml, but depending on your OS, it could be [elsewhere](https://pkg.go.dev/os#UserConfigDir).
* Run a simple command in the CLI like `go run main.go version`
* Only the version should show, not with the error like below:
```
Error Reading in file: /path/to/your/.vultr-cli.yaml
Vultr-CLI v3.0.2
```

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #433 

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
