### PR TITLE
Unify float precision on all printers

### DIFF
--- a/cmd/account/printer.go
+++ b/cmd/account/printer.go
@@ -39,10 +39,10 @@ func (a *AccountPrinter) Columns() [][]string {
 // Data ...
 func (a *AccountPrinter) Data() [][]string {
 	return [][]string{0: {
-		strconv.FormatFloat(float64(a.Account.Balance), 'f', utils.DecimalPrecision, 32),
-		strconv.FormatFloat(float64(a.Account.PendingCharges), 'f', utils.DecimalPrecision, 32),
+		strconv.FormatFloat(float64(a.Account.Balance), 'f', utils.FloatPrecision, 32),
+		strconv.FormatFloat(float64(a.Account.PendingCharges), 'f', utils.FloatPrecision, 32),
 		a.Account.LastPaymentDate,
-		strconv.FormatFloat(float64(a.Account.LastPaymentAmount), 'f', utils.DecimalPrecision, 32),
+		strconv.FormatFloat(float64(a.Account.LastPaymentAmount), 'f', utils.FloatPrecision, 32),
 		a.Account.Name,
 		a.Account.Email,
 		printer.ArrayOfStringsToString(a.Account.ACL),

--- a/cmd/billing/printer.go
+++ b/cmd/billing/printer.go
@@ -51,8 +51,8 @@ func (b *BillingHistoryPrinter) Data() [][]string {
 			b.Billing[i].Date,
 			b.Billing[i].Type,
 			b.Billing[i].Description,
-			strconv.FormatFloat(float64(b.Billing[i].Amount), 'f', utils.DecimalPrecision, 32),
-			strconv.FormatFloat(float64(b.Billing[i].Balance), 'f', utils.DecimalPrecision, 32),
+			strconv.FormatFloat(float64(b.Billing[i].Amount), 'f', utils.FloatPrecision, 32),
+			strconv.FormatFloat(float64(b.Billing[i].Balance), 'f', utils.FloatPrecision, 32),
 		})
 	}
 	return data
@@ -104,8 +104,8 @@ func (b *BillingInvoicesPrinter) Data() [][]string {
 			strconv.Itoa(b.Invoices[i].ID),
 			b.Invoices[i].Date,
 			b.Invoices[i].Description,
-			strconv.FormatFloat(float64(b.Invoices[i].Amount), 'f', utils.DecimalPrecision, 32),
-			strconv.FormatFloat(float64(b.Invoices[i].Balance), 'f', utils.DecimalPrecision, 32),
+			strconv.FormatFloat(float64(b.Invoices[i].Amount), 'f', utils.FloatPrecision, 32),
+			strconv.FormatFloat(float64(b.Invoices[i].Balance), 'f', utils.FloatPrecision, 32),
 		})
 	}
 	return data
@@ -150,8 +150,8 @@ func (b *BillingInvoicePrinter) Data() [][]string {
 		strconv.Itoa(b.Invoice.ID),
 		b.Invoice.Date,
 		b.Invoice.Description,
-		strconv.FormatFloat(float64(b.Invoice.Amount), 'f', utils.DecimalPrecision, 32),
-		strconv.FormatFloat(float64(b.Invoice.Balance), 'f', utils.DecimalPrecision, 32),
+		strconv.FormatFloat(float64(b.Invoice.Amount), 'f', utils.FloatPrecision, 32),
+		strconv.FormatFloat(float64(b.Invoice.Balance), 'f', utils.FloatPrecision, 32),
 	}}
 }
 
@@ -207,8 +207,8 @@ func (b *BillingInvoiceItemsPrinter) Data() [][]string {
 			b.InvoiceItems[i].EndDate,
 			strconv.Itoa(b.InvoiceItems[i].Units),
 			b.InvoiceItems[i].UnitType,
-			strconv.FormatFloat(float64(b.InvoiceItems[i].UnitPrice), 'f', utils.DecimalPrecision, 32),
-			strconv.FormatFloat(float64(b.InvoiceItems[i].Total), 'f', utils.DecimalPrecision, 32),
+			strconv.FormatFloat(float64(b.InvoiceItems[i].UnitPrice), 'f', utils.FloatPrecision, 32),
+			strconv.FormatFloat(float64(b.InvoiceItems[i].Total), 'f', utils.FloatPrecision, 32),
 		})
 	}
 

--- a/cmd/plans/printer.go
+++ b/cmd/plans/printer.go
@@ -58,7 +58,7 @@ func (p *PlansPrinter) Data() [][]string {
 			strconv.Itoa(p.Plans[i].Disk),
 			strconv.Itoa(p.Plans[i].DiskCount),
 			strconv.Itoa(p.Plans[i].Bandwidth),
-			strconv.FormatFloat(float64(p.Plans[i].MonthlyCost), 'f', utils.DecimalPrecision, 32),
+			strconv.FormatFloat(float64(p.Plans[i].MonthlyCost), 'f', utils.FloatPrecision, 32),
 			p.Plans[i].Type,
 			strconv.Itoa(p.Plans[i].GPUVRAM),
 			p.Plans[i].GPUType,
@@ -128,7 +128,7 @@ func (m *MetalPlansPrinter) Data() [][]string {
 			strconv.Itoa(m.Plans[i].Disk),
 			strconv.Itoa(m.Plans[i].DiskCount),
 			strconv.Itoa(m.Plans[i].Bandwidth),
-			strconv.FormatFloat(float64(m.Plans[i].MonthlyCost), 'f', utils.DecimalPrecision, 32),
+			strconv.FormatFloat(float64(m.Plans[i].MonthlyCost), 'f', utils.FloatPrecision, 32),
 			m.Plans[i].Type,
 			printer.ArrayOfStringsToString(m.Plans[i].Locations),
 		})

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -11,10 +11,8 @@ import (
 
 const (
 	PerPageDefault int = 100
-	// TODO; replace
-	DecimalPrecision int = 4
-	FloatPrecision   int = 4
-	FloatBitDepth    int = 32
+	FloatPrecision int = 2
+	FloatBitDepth  int = 32
 )
 
 // SetOptions initializes values used in all CLI commands


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Make all float formatting for the printers use two digit precision.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
