### PR TITLE
Fix command to install vultr-cli using Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you are to visit the `vultr-cli` [releases](https://github.com/vultr/vultr-cl
 
 You will need Go installed on your machine in order to work with the source (and make if you decide to pull the repo down).
 
-`go get -u github.com/vultr/vultr-cli/v3`
+`go install github.com/vultr/vultr-cli/v3@latest`
 
 Another way to build from source is to
 


### PR DESCRIPTION
## Description

Command:

        go get -u github.com/vultr/vultr-cli/v3

doesn't seem to work any longer, it returns:

go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
