### PR TITLE
Make bool descrition format consistent with other places

### DIFF
--- a/cmd/containerregistry/containerregistry.go
+++ b/cmd/containerregistry/containerregistry.go
@@ -258,7 +258,7 @@ func NewCmdContainerRegistry(base *cli.Base) *cobra.Command { //nolint:funlen,go
 		"public",
 		"p",
 		false,
-		"If the registry is publicly available. Should be true | false (default is false)",
+		"make the registry publicly available | true or false",
 	)
 	if err := create.MarkFlagRequired("public"); err != nil {
 		fmt.Printf("error marking container registry create 'public' flag required: %v", err)


### PR DESCRIPTION
## Description

Just made option description consistent with other bool options.

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
