### PR TITLE
Deprecate Redis-Named Fields

### DIFF
--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -202,9 +202,9 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 				return fmt.Errorf("error parsing flag 'mysql-long-query-time' for database create : %v", errMt)
 			}
 
-			redisEvictionPolicy, errEe := cmd.Flags().GetString("redis-eviction-policy")
+			evictionPolicy, errEe := cmd.Flags().GetString("eviction-policy")
 			if errEe != nil {
-				return fmt.Errorf("error parsing flag 'redis-eviction-policy' for database create : %v", errEe)
+				return fmt.Errorf("error parsing flag 'eviction-policy' for database create : %v", errEe)
 			}
 
 			o.CreateReq = &govultr.DatabaseCreateReq{
@@ -222,7 +222,7 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 				MySQLRequirePrimaryKey: &mysqlRequirePrimaryKey,
 				MySQLSlowQueryLog:      &mySQLSlowQueryLog,
 				MySQLLongQueryTime:     mySQLLongQueryTime,
-				RedisEvictionPolicy:    redisEvictionPolicy,
+				EvictionPolicy:         evictionPolicy,
 			}
 
 			db, err := o.create()
@@ -296,7 +296,7 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 		0,
 		"long query time for the new mysql managed database when slow query logging is enabled",
 	)
-	create.Flags().String("redis-eviction-policy", "", "eviction policy for the new redis managed database")
+	create.Flags().String("eviction-policy", "", "eviction policy for the new caching managed database")
 
 	// Update
 	update := &cobra.Command{
@@ -362,9 +362,9 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 				return fmt.Errorf("error parsing flag 'mysql-long-query-time' for database update : %v", errMt)
 			}
 
-			redisEvictionPolicy, errEe := cmd.Flags().GetString("redis-eviction-policy")
+			evictionPolicy, errEe := cmd.Flags().GetString("eviction-policy")
 			if errEe != nil {
-				return fmt.Errorf("error parsing flag 'redis-eviction-policy' for database update : %v", errEe)
+				return fmt.Errorf("error parsing flag 'eviction-policy' for database update : %v", errEe)
 			}
 
 			o.UpdateReq = &govultr.DatabaseUpdateReq{}
@@ -409,8 +409,8 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 				o.UpdateReq.MySQLLongQueryTime = mySQLLongQueryTime
 			}
 
-			if cmd.Flags().Changed("redis-eviction-policy") {
-				o.UpdateReq.RedisEvictionPolicy = redisEvictionPolicy
+			if cmd.Flags().Changed("eviction-policy") {
+				o.UpdateReq.EvictionPolicy = evictionPolicy
 			}
 
 			db, err := o.update()
@@ -454,7 +454,7 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 		0,
 		"long query time for the mysql managed database when slow query logging is enabled",
 	)
-	update.Flags().String("redis-eviction-policy", "", "eviction policy for the redis managed database")
+	update.Flags().String("eviction-policy", "", "eviction policy for the caching managed database")
 
 	// Delete
 	del := &cobra.Command{
@@ -675,7 +675,7 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 	// User ACL
 	userACL := &cobra.Command{
 		Use:   "acl",
-		Short: "Commands to manage database user access control (Redis only)",
+		Short: "Commands to manage database user access control (Caching only)",
 	}
 
 	// User ACL Update
@@ -689,24 +689,24 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			categories, errCa := cmd.Flags().GetStringSlice("redis-acl-categories")
+			categories, errCa := cmd.Flags().GetStringSlice("acl-categories")
 			if errCa != nil {
-				return fmt.Errorf("error parsing flag 'redis-acl-categories' for database user ACL update : %v", errCa)
+				return fmt.Errorf("error parsing flag 'acl-categories' for database user ACL update : %v", errCa)
 			}
 
-			channels, errCh := cmd.Flags().GetStringSlice("redis-acl-channels")
+			channels, errCh := cmd.Flags().GetStringSlice("acl-channels")
 			if errCh != nil {
-				return fmt.Errorf("error parsing flag 'redis-acl-channels' for database user ACL update : %v", errCh)
+				return fmt.Errorf("error parsing flag 'acl-channels' for database user ACL update : %v", errCh)
 			}
 
-			commands, errCo := cmd.Flags().GetStringSlice("redis-acl-commands")
+			commands, errCo := cmd.Flags().GetStringSlice("acl-commands")
 			if errCo != nil {
-				return fmt.Errorf("error parsing flag 'redis-acl-commands' for database user ACL update : %v", errCo)
+				return fmt.Errorf("error parsing flag 'acl-commands' for database user ACL update : %v", errCo)
 			}
 
-			keys, errKe := cmd.Flags().GetStringSlice("redis-acl-keys")
+			keys, errKe := cmd.Flags().GetStringSlice("acl-keys")
 			if errKe != nil {
-				return fmt.Errorf("error parsing flag 'redis-acl-keys' for database user ACL update : %v", errKe)
+				return fmt.Errorf("error parsing flag 'acl-keys' for database user ACL update : %v", errKe)
 			}
 
 			permission, errPe := cmd.Flags().GetString("permission")
@@ -716,20 +716,20 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 
 			o.UserUpdateACLReq = &govultr.DatabaseUserACLReq{}
 
-			if cmd.Flags().Changed("redis-acl-categories") {
-				o.UserUpdateACLReq.RedisACLCategories = &categories
+			if cmd.Flags().Changed("acl-categories") {
+				o.UserUpdateACLReq.ACLCategories = &categories
 			}
 
-			if cmd.Flags().Changed("redis-acl-channels") {
-				o.UserUpdateACLReq.RedisACLChannels = &channels
+			if cmd.Flags().Changed("acl-channels") {
+				o.UserUpdateACLReq.ACLChannels = &channels
 			}
 
-			if cmd.Flags().Changed("redis-acl-commands") {
-				o.UserUpdateACLReq.RedisACLCommands = &commands
+			if cmd.Flags().Changed("acl-commands") {
+				o.UserUpdateACLReq.ACLCommands = &commands
 			}
 
-			if cmd.Flags().Changed("redis-acl-keys") {
-				o.UserUpdateACLReq.RedisACLKeys = &keys
+			if cmd.Flags().Changed("acl-keys") {
+				o.UserUpdateACLReq.ACLKeys = &keys
 			}
 
 			if cmd.Flags().Changed("permission") {
@@ -749,32 +749,32 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 	}
 
 	userACLUpdate.Flags().StringSlice(
-		"redis-acl-categories",
+		"acl-categories",
 		[]string{},
 		"list of rules for command categories",
 	)
 	userACLUpdate.Flags().StringSlice(
-		"redis-acl-channels",
+		"acl-channels",
 		[]string{},
 		"list of publish/subscribe channel patterns",
 	)
 	userACLUpdate.Flags().StringSlice(
-		"redis-acl-commands",
+		"acl-commands",
 		[]string{},
 		"list of rules for individual commands",
 	)
 	userACLUpdate.Flags().StringSlice(
-		"redis-acl-keys",
+		"acl-keys",
 		[]string{},
 		"list of key access rules",
 	)
 	userACLUpdate.Flags().String("permission", "", "the kafka permission level")
 
 	userACLUpdate.MarkFlagsOneRequired(
-		"redis-acl-categories",
-		"redis-acl-channels",
-		"redis-acl-commands",
-		"redis-acl-keys",
+		"acl-categories",
+		"acl-channels",
+		"acl-commands",
+		"acl-keys",
 		"permission",
 	)
 
@@ -1457,7 +1457,7 @@ func NewCmdDatabase(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 	migrationStart.Flags().String(
 		"username",
 		"",
-		"source username for the managed database migration (uses `default` for Redis if omitted)",
+		"source username for the managed database migration (uses `default` for caching databases if omitted)",
 	)
 	migrationStart.Flags().String("password", "", "source password for the managed database migration")
 	migrationStart.Flags().String(

--- a/cmd/database/printer.go
+++ b/cmd/database/printer.go
@@ -148,8 +148,8 @@ func (d *DBsPrinter) Data() [][]string { //nolint:funlen,gocyclo
 			data = append(data, []string{" "})
 		}
 
-		if d.DBs[i].DatabaseEngine == "redis" {
-			data = append(data, []string{"REDIS EVICTION POLICY", d.DBs[i].RedisEvictionPolicy})
+		if d.DBs[i].DatabaseEngine == "redis" || d.DBs[i].DatabaseEngine == "valkey" {
+			data = append(data, []string{"EVICTION POLICY", d.DBs[i].EvictionPolicy})
 		}
 
 		data = append(data, []string{"CLUSTER TIME ZONE", d.DBs[i].ClusterTimeZone})
@@ -249,8 +249,8 @@ func (d *DBsPrinter) Data() [][]string { //nolint:funlen,gocyclo
 					data = append(data, []string{" "})
 				}
 
-				if d.DBs[i].ReadReplicas[j].DatabaseEngine == "redis" {
-					data = append(data, []string{"REDIS EVICTION POLICY", d.DBs[i].ReadReplicas[j].RedisEvictionPolicy})
+				if d.DBs[i].ReadReplicas[j].DatabaseEngine == "redis" || d.DBs[i].ReadReplicas[j].DatabaseEngine == "valkey" {
+					data = append(data, []string{"EVICTION POLICY", d.DBs[i].ReadReplicas[j].EvictionPolicy})
 				}
 
 				data = append(data, []string{"CLUSTER TIME ZONE", d.DBs[i].ReadReplicas[j].ClusterTimeZone})
@@ -404,8 +404,8 @@ func (d *DBPrinter) Data() [][]string { //nolint:funlen,gocyclo
 		data = append(data, []string{" "})
 	}
 
-	if d.DB.DatabaseEngine == "redis" {
-		data = append(data, []string{"REDIS EVICTION POLICY", d.DB.RedisEvictionPolicy})
+	if d.DB.DatabaseEngine == "redis" || d.DB.DatabaseEngine == "valkey" {
+		data = append(data, []string{"EVICTION POLICY", d.DB.EvictionPolicy})
 	}
 
 	data = append(data, []string{"CLUSTER TIME ZONE", d.DB.ClusterTimeZone})
@@ -505,8 +505,8 @@ func (d *DBPrinter) Data() [][]string { //nolint:funlen,gocyclo
 				data = append(data, []string{" "})
 			}
 
-			if d.DB.ReadReplicas[i].DatabaseEngine == "redis" {
-				data = append(data, []string{"REDIS EVICTION POLICY", d.DB.ReadReplicas[i].RedisEvictionPolicy})
+			if d.DB.ReadReplicas[i].DatabaseEngine == "redis" || d.DB.ReadReplicas[i].DatabaseEngine == "valkey" {
+				data = append(data, []string{"EVICTION POLICY", d.DB.ReadReplicas[i].EvictionPolicy})
 			}
 
 			data = append(data, []string{"CLUSTER TIME ZONE", d.DB.ReadReplicas[i].ClusterTimeZone})
@@ -778,10 +778,10 @@ func (u *UsersPrinter) Data() [][]string {
 		if u.Users[i].AccessControl != nil {
 			data = append(data,
 				[]string{"ACCESS CONTROL"},
-				[]string{"REDIS ACL CATEGORIES", printer.ArrayOfStringsToString(u.Users[i].AccessControl.RedisACLCategories)},
-				[]string{"REDIS ACL CHANNELS", printer.ArrayOfStringsToString(u.Users[i].AccessControl.RedisACLChannels)},
-				[]string{"REDIS ACL COMMANDS", printer.ArrayOfStringsToString(u.Users[i].AccessControl.RedisACLCommands)},
-				[]string{"REDIS ACL KEYS", printer.ArrayOfStringsToString(u.Users[i].AccessControl.RedisACLKeys)},
+				[]string{"ACL CATEGORIES", printer.ArrayOfStringsToString(u.Users[i].AccessControl.ACLCategories)},
+				[]string{"ACL CHANNELS", printer.ArrayOfStringsToString(u.Users[i].AccessControl.ACLChannels)},
+				[]string{"ACL COMMANDS", printer.ArrayOfStringsToString(u.Users[i].AccessControl.ACLCommands)},
+				[]string{"ACL KEYS", printer.ArrayOfStringsToString(u.Users[i].AccessControl.ACLKeys)},
 			)
 		}
 
@@ -846,10 +846,10 @@ func (u *UserPrinter) Data() [][]string {
 	if u.User.AccessControl != nil {
 		data = append(data,
 			[]string{"ACCESS CONTROL"},
-			[]string{"REDIS ACL CATEGORIES", printer.ArrayOfStringsToString(u.User.AccessControl.RedisACLCategories)},
-			[]string{"REDIS ACL CHANNELS", printer.ArrayOfStringsToString(u.User.AccessControl.RedisACLChannels)},
-			[]string{"REDIS ACL COMMANDS", printer.ArrayOfStringsToString(u.User.AccessControl.RedisACLCommands)},
-			[]string{"REDIS ACL KEYS", printer.ArrayOfStringsToString(u.User.AccessControl.RedisACLKeys)},
+			[]string{"ACL CATEGORIES", printer.ArrayOfStringsToString(u.User.AccessControl.ACLCategories)},
+			[]string{"ACL CHANNELS", printer.ArrayOfStringsToString(u.User.AccessControl.ACLChannels)},
+			[]string{"ACL COMMANDS", printer.ArrayOfStringsToString(u.User.AccessControl.ACLCommands)},
+			[]string{"ACL KEYS", printer.ArrayOfStringsToString(u.User.AccessControl.ACLKeys)},
 		)
 	}
 


### PR DESCRIPTION
## Description
This PR matches the recent Govultr updates to remove the Redis-named fields and properties, replacing them with generic versions to eventually support other caching engines.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
