### PR TITLE
Update --userdata usage to be more clear

### DIFF
--- a/cmd/instance/instance.go
+++ b/cmd/instance/instance.go
@@ -364,7 +364,7 @@ func NewCmdInstance(base *cli.Base) *cobra.Command { //nolint:funlen,gocyclo
 		"userdata",
 		"u",
 		"",
-		"plain text userdata you want to give this instance which the CLI will base64 encode",
+		"plain text userdata you want to give this instance",
 	)
 	create.Flags().BoolP("notify", "n", false, "notify when instance has been created | true or false")
 	create.Flags().BoolP("ddos", "d", false, "enable ddos protection | true or false")


### PR DESCRIPTION
Don't mention how data is processed under the hood. This avoids someone quickly reading the line and thinking it expects base64 input.