### PR TITLE
Remove unused lint config rules exclusion

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -116,6 +116,5 @@ issues:
   exclude:
     - abcdef
     - ST1023
-  exclude-rules:
 run:
   timeout: 5m


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Removes an unused config block for golangci-lint