### PR TITLE
Fix object storage printer output for tiers

### DIFF
--- a/cmd/objectstorage/objectstorage.go
+++ b/cmd/objectstorage/objectstorage.go
@@ -328,7 +328,7 @@ func NewCmdObjectStorage(base *cli.Base) *cobra.Command { //nolint:gocyclo
 				return fmt.Errorf("error retrieving object storage cluster tier list : %v", err)
 			}
 
-			data := &ObjectStorageTiersPrinter{Tiers: clusterTiers}
+			data := &ObjectStorageClusterTiersPrinter{Tiers: clusterTiers}
 			o.Base.Printer.Display(data, nil)
 
 			return nil

--- a/cmd/objectstorage/printer.go
+++ b/cmd/objectstorage/printer.go
@@ -324,7 +324,7 @@ func (o *ObjectStorageClusterTiersPrinter) Columns() [][]string {
 // Data ...
 func (o *ObjectStorageClusterTiersPrinter) Data() [][]string {
 	if len(o.Tiers) == 0 {
-		return [][]string{0: {"---", "---", "---", "---", "---", "---", "---", "---"}}
+		return [][]string{0: {"---", "---", "---", "---", "---", "---", "---"}}
 	}
 
 	var data [][]string

--- a/cmd/objectstorage/printer.go
+++ b/cmd/objectstorage/printer.go
@@ -253,8 +253,8 @@ func (o *ObjectStorageTiersPrinter) Data() [][]string {
 	var data [][]string
 	for i := range o.Tiers {
 		var regions []string
-		for _, id := range o.Tiers[i].Locations {
-			regions = append(regions, id.Region)
+		for j := range o.Tiers[i].Locations {
+			regions = append(regions, o.Tiers[i].Locations[j].Region)
 		}
 		data = append(data, []string{
 			strconv.Itoa(o.Tiers[i].ID),

--- a/cmd/objectstorage/printer.go
+++ b/cmd/objectstorage/printer.go
@@ -290,3 +290,75 @@ func (o *ObjectStorageTiersPrinter) Data() [][]string {
 func (o *ObjectStorageTiersPrinter) Paging() [][]string {
 	return nil
 }
+
+// ======================================
+
+// ObjectStorageTiersPrinter ...
+type ObjectStorageClusterTiersPrinter struct {
+	Tiers []govultr.ObjectStorageTier `json:"tiers"`
+}
+
+// JSON ...
+func (o *ObjectStorageClusterTiersPrinter) JSON() []byte {
+	return printer.MarshalObject(o, "json")
+}
+
+// YAML ...
+func (o *ObjectStorageClusterTiersPrinter) YAML() []byte {
+	return printer.MarshalObject(o, "yaml")
+}
+
+// Columns ...
+func (o *ObjectStorageClusterTiersPrinter) Columns() [][]string {
+	return [][]string{0: {
+		"ID",
+		"SLUG",
+		"PRICE",
+		"PRICE BANDWIDTH",
+		"PRICE DISK",
+		"RATELIMIT OPS",
+		"RATELIMIT BYTES",
+	}}
+}
+
+// Data ...
+func (o *ObjectStorageClusterTiersPrinter) Data() [][]string {
+	if len(o.Tiers) == 0 {
+		return [][]string{0: {"---", "---", "---", "---", "---", "---", "---", "---"}}
+	}
+
+	var data [][]string
+	for i := range o.Tiers {
+		data = append(data, []string{
+			strconv.Itoa(o.Tiers[i].ID),
+			o.Tiers[i].Slug,
+			strconv.FormatFloat(
+				float64(o.Tiers[i].Price),
+				'f',
+				utils.FloatPrecision,
+				utils.FloatBitDepth,
+			),
+			strconv.FormatFloat(
+				float64(o.Tiers[i].PriceBandwidthGB),
+				'f',
+				utils.FloatPrecision,
+				utils.FloatBitDepth,
+			),
+			strconv.FormatFloat(
+				float64(o.Tiers[i].PriceDiskGB),
+				'f',
+				utils.FloatPrecision,
+				utils.FloatBitDepth,
+			),
+			strconv.Itoa(o.Tiers[i].RateLimitOpsSec),
+			strconv.Itoa(o.Tiers[i].RateLimitBytesSec),
+		})
+	}
+
+	return data
+}
+
+// Paging ...
+func (o *ObjectStorageClusterTiersPrinter) Paging() [][]string {
+	return nil
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* adds a separate printer for the response from the cluster tiers endpoint which does not have the location data
* makes location data loop use the index instead of copy
### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
