### PR TITLE
Add user and password display for instances and bare metals

### DIFF
--- a/cmd/baremetal/printer.go
+++ b/cmd/baremetal/printer.go
@@ -88,38 +88,38 @@ func (b *BareMetalPrinter) YAML() []byte {
 
 // Columns ...
 func (b *BareMetalPrinter) Columns() [][]string {
-	return [][]string{0: {
-		"ID",
-		"IP",
-		"MAC ADDRESS",
-		"LABEL",
-		"OS",
-		"STATUS",
-		"REGION",
-		"CPU",
-		"RAM",
-		"DISK",
-		"FEATURES",
-		"TAGS",
-	}}
+	return [][]string{0: {"BARE METAL INFO"}}
 }
 
 // Data ...
 func (b *BareMetalPrinter) Data() [][]string {
-	return [][]string{0: {
-		b.BareMetal.ID,
-		b.BareMetal.MainIP,
-		strconv.Itoa(b.BareMetal.MacAddress),
-		b.BareMetal.Label,
-		b.BareMetal.Os,
-		b.BareMetal.Status,
-		b.BareMetal.Region,
-		strconv.Itoa(b.BareMetal.CPUCount),
-		b.BareMetal.RAM,
-		b.BareMetal.Disk,
-		printer.ArrayOfStringsToString(b.BareMetal.Features),
-		printer.ArrayOfStringsToString(b.BareMetal.Tags),
-	}}
+	var data [][]string
+	data = append(data,
+		[]string{"ID", b.BareMetal.ID},
+		[]string{"IP", b.BareMetal.MainIP},
+		[]string{"USER SCHEME", b.BareMetal.UserScheme},
+	)
+
+	if b.BareMetal.DefaultPassword != "" {
+		data = append(data, []string{"PASSWORD", b.BareMetal.DefaultPassword})
+	} else {
+		data = append(data, []string{"PASSWORD", "UNAVAILABLE"})
+	}
+
+	data = append(data,
+		[]string{"MAC ADDRESS", strconv.Itoa(b.BareMetal.MacAddress)},
+		[]string{"LABEL", b.BareMetal.Label},
+		[]string{"OS", b.BareMetal.Os},
+		[]string{"STATUS", b.BareMetal.Status},
+		[]string{"REGION", b.BareMetal.Region},
+		[]string{"CPU", strconv.Itoa(b.BareMetal.CPUCount)},
+		[]string{"RAM", b.BareMetal.RAM},
+		[]string{"DISK", b.BareMetal.Disk},
+		[]string{"FEATURES", printer.ArrayOfStringsToString(b.BareMetal.Features)},
+		[]string{"TAGS", printer.ArrayOfStringsToString(b.BareMetal.Tags)},
+	)
+
+	return data
 }
 
 // Paging ...

--- a/cmd/instance/printer.go
+++ b/cmd/instance/printer.go
@@ -103,6 +103,16 @@ func (i *InstancePrinter) Data() [][]string {
 		[]string{"RAM", strconv.Itoa(i.Instance.RAM)},
 		[]string{"DISK", strconv.Itoa(i.Instance.Disk)},
 		[]string{"MAIN IP", i.Instance.MainIP},
+		[]string{"USER SCHEME", i.Instance.UserScheme},
+	)
+
+	if i.Instance.DefaultPassword != "" {
+		data = append(data, []string{"PASSWORD", i.Instance.DefaultPassword})
+	} else {
+		data = append(data, []string{"PASSWORD", "UNAVAILABLE"})
+	}
+
+	data = append(data,
 		[]string{"VCPU COUNT", strconv.Itoa(i.Instance.VCPUCount)},
 		[]string{"REGION", i.Instance.Region},
 		[]string{"DATE CREATED", i.Instance.DateCreated},


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* Adds the user scheme and password display for newly created instances and bare metals
* Will show `UNAVAILABLE` when the password eventually stops returning through the API (10 minutes after creation)

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
