### PR TITLE
snapshots: Add `create-url --uefi` boolean flag and `--description` flag

### DIFF
--- a/cmd/snapshot/snapshot.go
+++ b/cmd/snapshot/snapshot.go
@@ -126,6 +126,12 @@ func NewCmdSnapshot(base *cli.Base) *cobra.Command {
 				URL: url,
 			}
 
+			if desc, err := cmd.Flags().GetString("description"); err != nil {
+				return fmt.Errorf("error parsing flag 'description' for createURL : %v", err)
+			} else {
+				o.URLReq.Description = desc
+			}
+
 			if cmd.Flags().Changed("uefi") {
 				if b, err := cmd.Flags().GetBool("uefi"); err != nil {
 					return fmt.Errorf("error parsing flag 'uefi' for createURL : %v", err)
@@ -149,6 +155,7 @@ func NewCmdSnapshot(base *cli.Base) *cobra.Command {
 	}
 
 	createURL.Flags().StringP("url", "u", "", "Remote URL from where the snapshot will be downloaded.")
+	createURL.Flags().StringP("description", "d", "", "Set the description of the snapshot (defaults to base filename from request URL).")
 	createURL.Flags().Bool("uefi", false, "Mark snapshot as UEFI.")
 	if err := createURL.MarkFlagRequired("url"); err != nil {
 		fmt.Printf("error marking snapshot create 'url' flag required: %v", err)

--- a/cmd/snapshot/snapshot.go
+++ b/cmd/snapshot/snapshot.go
@@ -126,6 +126,16 @@ func NewCmdSnapshot(base *cli.Base) *cobra.Command {
 				URL: url,
 			}
 
+			if cmd.Flags().Changed("uefi") {
+				if b, err := cmd.Flags().GetBool("uefi"); err != nil {
+					return fmt.Errorf("error parsing flag 'uefi' for createURL : %v", err)
+				} else if b {
+					o.URLReq.UEFI = govultr.SnapshotURLReqUEFIYes
+				} else {
+					o.URLReq.UEFI = govultr.SnapshotURLReqUEFINo
+				}
+			}
+
 			snapshot, err := o.createURL()
 			if err != nil {
 				return fmt.Errorf("error creating snapshot from URL : %v", err)
@@ -139,6 +149,7 @@ func NewCmdSnapshot(base *cli.Base) *cobra.Command {
 	}
 
 	createURL.Flags().StringP("url", "u", "", "Remote URL from where the snapshot will be downloaded.")
+	createURL.Flags().Bool("uefi", false, "Mark snapshot as UEFI.")
 	if err := createURL.MarkFlagRequired("url"); err != nil {
 		fmt.Printf("error marking snapshot create 'url' flag required: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
## snapshots: Add `create-url --uefi` boolean flag
Differentiate between unset and false by using flags.Changed().

(Note the style in here leads to a lot of unecessary error checking --
and hence reference to string flag names. IMO it's nicer to create a
flags/vals struct and use the *Var* variants from pflags...)

## snapshots: Add `create-url --description` flag

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?

This PR builds on top of https://github.com/vultr/govultr/pull/390. I tested them together e2e to create a UEFI snapshot from a URL with a custom description, and booted a new instance from it.