### PR TITLE
Update govultr from v3.28.1 to v3.30.0

### DIFF
--- a/cmd/baremetal/printer.go
+++ b/cmd/baremetal/printer.go
@@ -196,8 +196,8 @@ func (b *BareMetalBandwidthPrinter) Data() [][]string {
 	for k := range b.Bandwidth.Bandwidth {
 		data = append(data, []string{
 			k,
-			strconv.Itoa(b.Bandwidth.Bandwidth[k].IncomingBytes),
-			strconv.Itoa(b.Bandwidth.Bandwidth[k].OutgoingBytes),
+			strconv.FormatInt(b.Bandwidth.Bandwidth[k].IncomingBytes, 10),
+			strconv.FormatInt(b.Bandwidth.Bandwidth[k].OutgoingBytes, 10),
 		})
 	}
 

--- a/cmd/instance/printer.go
+++ b/cmd/instance/printer.go
@@ -175,8 +175,8 @@ func (b *BandwidthPrinter) Data() [][]string {
 	for i := range b.Bandwidth.Bandwidth {
 		data = append(data, []string{
 			i,
-			strconv.Itoa(b.Bandwidth.Bandwidth[i].IncomingBytes),
-			strconv.Itoa(b.Bandwidth.Bandwidth[i].OutgoingBytes),
+			strconv.FormatInt(b.Bandwidth.Bandwidth[i].IncomingBytes, 10),
+			strconv.FormatInt(b.Bandwidth.Bandwidth[i].OutgoingBytes, 10),
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
-	github.com/vultr/govultr/v3 v3.28.1
+	github.com/vultr/govultr/v3 v3.30.0
 	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/vultr/govultr/v3 v3.28.1 h1:KR3LhppYARlBujY7+dcrE7YKL0Yo9qXL+msxykKQrLI=
-github.com/vultr/govultr/v3 v3.28.1/go.mod h1:2zyUw9yADQaGwKnwDesmIOlBNLrm7edsCfWHFJpWKf8=
+github.com/vultr/govultr/v3 v3.30.0 h1:kTeDJ+5or6g4CQJmD6Kmz4R63B18poNZ8RP87r9LZdg=
+github.com/vultr/govultr/v3 v3.30.0/go.mod h1:2zyUw9yADQaGwKnwDesmIOlBNLrm7edsCfWHFJpWKf8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
* Updates govultr from v3.28.1 to v3.30.0
* Changes bandwidth format type for instance and bare metal printers